### PR TITLE
Fix copy/paste typos in OO Camera APIs

### DIFF
--- a/reference/java-api.md
+++ b/reference/java-api.md
@@ -57,8 +57,7 @@ The following tables describe the Java classes and their methods.
 | &nbsp;&nbsp; public static int [pixelGetRed](camera.md#wb_camera_get_image)(int pixel);                              |
 | &nbsp;&nbsp; public static int [pixelGetGreen](camera.md#wb_camera_get_image)(int pixel);                            |
 | &nbsp;&nbsp; public static int [pixelGetBlue](camera.md#wb_camera_get_image)(int pixel);                             |
-| &nbsp;&nbsp; public static int [pixelGetGray](camera.md#wb_camera_get_image)(int pixel);                             |
-| &nbsp;&nbsp;&nbsp;&nbsp; int width, int x, int y);                                                                   |
+| &nbsp;&nbsp; public static int [pixelGetGray](camera.md#wb_camera_get_image)(int pixel);                             |                                                               |
 | &nbsp;&nbsp; public int [saveImage](camera.md#wb_camera_save_image)(String filename, int quality);                   |
 | }                                                                                                                    |
 

--- a/reference/python-api.md
+++ b/reference/python-api.md
@@ -57,7 +57,6 @@ The following tables describe the Python classes and their methods.
 | &nbsp;&nbsp; imageGetBlue = staticmethod(imageGetBlue)                                         |
 | &nbsp;&nbsp; def [imageGetGray](camera.md#wb_camera_get_image)(image, width, x, y)             |
 | &nbsp;&nbsp; imageGetGray = staticmethod(imageGetGray)                                         |
-| &nbsp;&nbsp; rangeImageGetDepth = staticmethod(rangeImageGetDepth)                             |
 | &nbsp;&nbsp; def [saveImage](camera.md#wb_camera_save_image)(self, filename, quality)          |
 
 %end


### PR DESCRIPTION
Remove wrong line probably remaining after a copy and paste.