### PR TITLE
Fix prefix of ROS API services and topics

### DIFF
--- a/reference/ros-api.md
+++ b/reference/ros-api.md
@@ -4,7 +4,7 @@ The following tables describe the available ros messages and services for each
 device.
 
 The <device\_name> should be replaced by the actual name of the device and each
-services/topics names should be prepended with '/<robot\_unique\_name>' (have a
+services/topics names should be prepended with ``/<robot_unique_name>`` (have a
 look at the [User
 Guide](http://www.cyberbotics.com/guide/using-ros.html#standard_ros_controller)
 for more information about the value of `robot_unique_name`).

--- a/reference/ros-api.md
+++ b/reference/ros-api.md
@@ -6,7 +6,7 @@ device.
 The <device\_name> should be replaced by the actual name of the device and each
 services/topics names should be prepended with ``<robot_unique_name>`` (have a
 look at the [User
-Guide](http://www.cyberbotics.com/guide/using-ros.php#standard_ros_controller)
+Guide](http://www.cyberbotics.com/guide/using-ros#standard_ros_controller)
 for more information about the value of `robot_unique_name`).
 
 ### Accelerometer

--- a/reference/ros-api.md
+++ b/reference/ros-api.md
@@ -4,7 +4,7 @@ The following tables describe the available ros messages and services for each
 device.
 
 The <device\_name> should be replaced by the actual name of the device and each
-services/topics names should be prepended with ``/<robot_unique_name>`` (have a
+services/topics names should be prepended with ``<robot_unique_name>`` (have a
 look at the [User
 Guide](http://www.cyberbotics.com/guide/using-ros.php#standard_ros_controller)
 for more information about the value of `robot_unique_name`).

--- a/reference/ros-api.md
+++ b/reference/ros-api.md
@@ -6,7 +6,7 @@ device.
 The <device\_name> should be replaced by the actual name of the device and each
 services/topics names should be prepended with ``/<robot_unique_name>`` (have a
 look at the [User
-Guide](http://www.cyberbotics.com/guide/using-ros.html#standard_ros_controller)
+Guide](http://www.cyberbotics.com/guide/using-ros.php#standard_ros_controller)
 for more information about the value of `robot_unique_name`).
 
 ### Accelerometer


### PR DESCRIPTION
The prefix described in the documentation doesn't match the one used in the code.
* documentation: ``/`` + ``<robot name >`` + ``/`` + ...
* code: ``<robot_name>`` + ``/`` + ...