### PR TITLE
Improve layout for small resolutions

### DIFF
--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -8,6 +8,7 @@
   width: 20%;
   position: fixed;
   height: 100%;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 .webots-doc #center {
@@ -48,6 +49,7 @@
   margin: 1em;
   padding-bottom: 0;
   margin-bottom: 0;
+  overflow-x: hidden;
 }
 .webots-doc #menu ul {
   list-style-type: none;

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -66,6 +66,7 @@
 .webots-doc #accordion li a,
 .webots-doc #accordion li ul li a {
   padding: 0.5em;
+  overflow-x: hidden;
 }
 .webots-doc #accordion li a {
   display: block;
@@ -120,6 +121,7 @@
 .webots-doc pre {
   margin: 30px;
   background-color: #ffeeee;
+  overflow-x: scroll;
 }
 .webots-doc code {
   background: transparent;

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -29,7 +29,7 @@
   top: 0;
 }
 .webots-doc #navigation {
-  margin: 0 2.5em 0;
+  margin: auto;
 }
 .webots-doc #title {
   margin-top: 0px;
@@ -54,14 +54,9 @@
   padding: 0;
 }
 .webots-doc #navigation > table {
-  width: 100%;
   text-align: center;
-  table-layout: fixed;
   font-size: 20px;
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  padding-top: 0;
-  padding-bottom: 0;
+  margin: 0em auto 0 auto;
 }
 .webots-doc #accordion li a,
 .webots-doc #accordion li ul li a {

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -118,7 +118,7 @@
 .webots-doc pre {
   margin: 30px;
   background-color: #ffeeee;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 .webots-doc code {
   background: transparent;

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -58,7 +58,7 @@
 .webots-doc #navigation > table {
   text-align: center;
   font-size: 20px;
-  margin: 0em auto 0 auto;
+  margin: 0 auto 0 auto;
 }
 .webots-doc #accordion li a,
 .webots-doc #accordion li ul li a {


### PR DESCRIPTION
- [x] Fix not highlighted code overflow: allow horizontal scroll when required
- [x] Fix texts of the menu overflow: crop it (horizontal scroll is not a good idea there, because scrolling vertically in the menu is recommended.).
- [x] Fix menu arrows overlap
- [x] Fix horizontal scroll bar of the menu shown for no reason
- [x] Test
    - [x] Embedded in Webots
    - [x] Firefox
    - [x] Chrome
    - [x] Safari
    - [x] IE
    - [x] Edge