### PR TITLE
Fix default repo which shouldn't be included in urls.

### DIFF
--- a/js/viewer.js
+++ b/js/viewer.js
@@ -120,11 +120,11 @@ function forgeUrl(page, anchor) {
   var newUrl = currentUrl;
   if (!local) {
     newUrl = "https://www.cyberbotics.com/doc/" + setup.book + "/" + page;
-    if (setup.tag != '' && setup.repository)
+    if (setup.tag != '' && setup.repository && setup.repository != "omichel")
       newUrl += "?version=" + setup.repository + ":" + setup.tag;
     else if (setup.tag != '')
       newUrl += "?version=" + setup.tag;
-    else if (setup.branch != '' && setup.repository)
+    else if (setup.branch != '' && setup.repository && setup.repository != "omichel")
       newUrl += "?version=" + setup.repository + ":" + setup.branch;
     else if (setup.branch != '')
       newUrl += "?version=" + setup.branch;


### PR DESCRIPTION
Issue introduced in #152

The default repository (`omichel`) were included systematically in the urls.

The fix is uploaded on the FTP.