### PR TITLE
Remove 3D view toolbar expression

### DIFF
--- a/guide/prerequisites.md
+++ b/guide/prerequisites.md
@@ -78,12 +78,12 @@ will soon explain the purpose of each directory.
 ### The Webots Graphical User Interface (GUI)
 
 The Webots main window is shown in [this
-figure](#the-webots-main-window-splits-into-four-dockable-subwindows-the-scene-tree-view-on-the-left-hand-side-including-a-panel-at-the-bottom-for-editing-fields-values-the-3d-view-in-the-center-the-text-editor-on-the-right-hand-side-and-the-console-at-bottom-of-the-window-note-that-some-of-these-subwindows-have-a-toolbar-with-buttons-the-main-menus-appear-on-the-top-of-the-main-window-the-virtual-time-counter-and-the-speedometer-are-displayed-in-the-right-part-of-the-3d-view-toolbar-the-status-text-is-displayed-in-the-bottom-left-of-the-main-window).
+figure](#the-webots-main-window-splits-into-four-dockable-subwindows-the-scene-tree-view-on-the-left-hand-side-including-a-panel-at-the-bottom-for-editing-fields-values-the-3d-view-in-the-center-the-text-editor-on-the-right-hand-side-and-the-console-at-bottom-of-the-window-note-that-some-of-these-subwindows-have-a-toolbar-with-buttons-the-main-menus-appear-on-the-top-of-the-main-window-the-virtual-time-counter-and-the-speedometer-are-displayed-in-the-right-part-of-the-main-toolbar-the-status-text-is-displayed-in-the-bottom-left-of-the-main-window).
 Make sure you understand well how the Webots main window is divided into
 subwindows before continuing. A more detailed description of the Webots GUI is
 provided in [this section](the-user-interface.md).
 
-%figure "The Webots main window splits into four dockable subwindows: the scene tree view on the left hand side (including a panel at the bottom for editing fields values), the 3D view in the center, the text editor on the right hand side, and the console at bottom of the window. Note that some of these subwindows have a toolbar with buttons. The main menus appear on the top of the main window. The virtual time counter and the speedometer are displayed in the right part of the 3D view toolbar. The status text is displayed in the bottom left of the main window."
+%figure "The Webots main window splits into four dockable subwindows: the scene tree view on the left hand side (including a panel at the bottom for editing fields values), the 3D view in the center, the text editor on the right hand side, and the console at bottom of the window. Note that some of these subwindows have a toolbar with buttons. The main menus appear on the top of the main window. The virtual time counter and the speedometer are displayed in the right part of the main toolbar. The status text is displayed in the bottom left of the main window."
 
 ![tutorial_gui.png](images/tutorial_gui.png)
 

--- a/guide/tutorial-1-your-first-simulation-in-webots-20-minutes.md
+++ b/guide/tutorial-1-your-first-simulation-in-webots-20-minutes.md
@@ -97,7 +97,7 @@ In the Scene Tree view, the fields are displayed in blue if they differ from the
 default values.
 
 Now your environment should look like the one depicted in the
-[figure](prerequisites.md#the-webots-main-window-splits-into-four-dockable-subwindows-the-scene-tree-view-on-the-left-hand-side-including-a-panel-at-the-bottom-for-editing-fields-values-the-3d-view-in-the-center-the-text-editor-on-the-right-hand-side-and-the-console-at-bottom-of-the-window-note-that-some-of-these-subwindows-have-a-toolbar-with-buttons-the-main-menus-appear-on-the-top-of-the-main-window-the-virtual-time-counter-and-the-speedometer-are-displayed-in-the-right-part-of-the-3d-view-toolbar-the-status-text-is-displayed-in-the-bottom-left-of-the-main-window).
+[figure](prerequisites.md#the-webots-main-window-splits-into-four-dockable-subwindows-the-scene-tree-view-on-the-left-hand-side-including-a-panel-at-the-bottom-for-editing-fields-values-the-3d-view-in-the-center-the-text-editor-on-the-right-hand-side-and-the-console-at-bottom-of-the-window-note-that-some-of-these-subwindows-have-a-toolbar-with-buttons-the-main-menus-appear-on-the-top-of-the-main-window-the-virtual-time-counter-and-the-speedometer-are-displayed-in-the-right-part-of-the-main-toolbar-the-status-text-is-displayed-in-the-bottom-left-of-the-main-window).
 
 > **Hands on**:
 Save the new world into your project by selecting the `File / Save World As...`

--- a/guide/tutorial-1-your-first-simulation-in-webots-20-minutes.md
+++ b/guide/tutorial-1-your-first-simulation-in-webots-20-minutes.md
@@ -36,7 +36,7 @@ Webots is currently open and runs an arbitrary simulation.
 
 > **Hands on**:
 Pause the current simulation by clicking on the `Pause` button of the 3D view.
-The simulation is paused if the virtual time counter on the 3D view toolbar is
+The simulation is paused if the virtual time counter on the main toolbar is
 stable.
 
 <!-- -->
@@ -145,7 +145,7 @@ simulation is paused and that the virtual time elapsed is 0.
 > **Theory**:
 When a Webots world is modified with the intention of being saved, it is
 fundamental that the simulation is first paused and reverted to its initial
-state, i.e. the virtual time counter on the 3D view toolbar should show
+state, i.e. the virtual time counter on the main toolbar should show
 0:00:00:000. Otherwise at each save, the position of each 3D objects can
 accumulate errors. Therefore, any modification of the world should be performed
 in that order: **pause, revert, modify and save the simulation**.


### PR DESCRIPTION
In documentation we still have references to ``3D view toolbar``, instead we should use ``main toolbar``.