### PR TITLE
Protect underscore in shaderpart.md

### DIFF
--- a/reference/shaderpart.md
+++ b/reference/shaderpart.md
@@ -38,7 +38,7 @@ The GLSL documentation is available from following sources:
 
 ### Variables
 
-All the standard GLSL variables are accessible from the GPU program (gl_Vertex, gl_ModelViewMatrix, etc.).
+All the standard GLSL variables are accessible from the GPU program (`gl_Vertex`, `gl_ModelViewMatrix`, etc.).
 Please refer to their documentation.
 
 The links between the VRML fields and these variables are various.


### PR DESCRIPTION
As reported in #193, deal better with the special MD characters by protecting them into back quotes.

Result here: https://www.cyberbotics.com/doc/reference/shaderpart?version=fix-underscores