### PR TITLE
Fix table rendering in Github view.

### DIFF
--- a/reference/shaderpart.md
+++ b/reference/shaderpart.md
@@ -45,7 +45,7 @@ The links between the VRML fields and these variables are various.
 Some of them are described in the following table:
 
 | VRML field(s)                                        | GLSL variable                                                   |
-| ==================================================== | =============================================================== |
+| ---------------------------------------------------- | --------------------------------------------------------------- |
 | `Material.ambientIntensity * Material.diffuseColor`  | `gl_FrontMaterial.ambient.rgb`                                  |
 | `Material.diffuseColor`                              | `gl_FrontMaterial.diffuse.rgb`                                  |
 | `Material.emissiveColor`                             | `gl_FrontMaterial.emissive.rgb`                                 |


### PR DESCRIPTION
Fixed comment in #195: the table of the shaderpart.md file is not rendered correctly in the Github view only.

Result: https://github.com/omichel/webots-doc/blob/fix-table-for-github-rendering/reference/shaderpart.md