### PR TITLE
add documentation about webots builtin uniforms

### DIFF
--- a/reference/composedshader.md
+++ b/reference/composedshader.md
@@ -18,6 +18,16 @@ If several [ShaderPart](shaderpart.md) nodes of the same type are given, then on
 
 The `uniforms` field is a list of [Uniform](uniform.md) nodes corresponding to the uniform variables passed to the [ShaderPart](shaderpart.md) programs.
 
+Webots provides a set of useful uniforms that can be invoked within a shader program and for which there is no need to add a [Uniform](uniform.md) field. To use them, simply declare them as `uniform` in your shader. For example, if you want to use the currently elapsed time, declare `uniform vec4 worldMatrix` and use the `worldMatrix` variable just like any other.
+
+Here is a list of supported variables:
+
+| type | name              | description                                                 |
+|------|-------------------|-------------------------------------------------------------|
+| vec4 | viewMatrix        | The matrix transformation from world space to camera space. |
+| vec4 | viewMatrixInverse | The inverse transformation of viewMatrix                    |
+| vec4 | worldMatrix       | The matrix transformation from model space to world space   |
+
 The `transparent` field indicates if the shader will use the alpha channel.
 If it is set to `FALSE` then
 the alpha channel will be ignored,

--- a/reference/composedshader.md
+++ b/reference/composedshader.md
@@ -24,9 +24,9 @@ Here is a list of supported variables:
 
 | type | name              | description                                                 |
 |------|-------------------|-------------------------------------------------------------|
-| vec4 | viewMatrix        | The matrix transformation from world space to camera space. |
-| vec4 | viewMatrixInverse | The inverse transformation of viewMatrix                    |
-| vec4 | worldMatrix       | The matrix transformation from model space to world space   |
+| mat4 | viewMatrix        | The matrix transformation from world space to camera space. |
+| mat4 | viewMatrixInverse | The inverse transformation of viewMatrix.                   |
+| mat4 | worldMatrix       | The matrix transformation from model space to world space.  |
 
 The `transparent` field indicates if the shader will use the alpha channel.
 If it is set to `FALSE` then

--- a/reference/composedshader.md
+++ b/reference/composedshader.md
@@ -18,7 +18,7 @@ If several [ShaderPart](shaderpart.md) nodes of the same type are given, then on
 
 The `uniforms` field is a list of [Uniform](uniform.md) nodes corresponding to the uniform variables passed to the [ShaderPart](shaderpart.md) programs.
 
-Webots provides a set of useful uniforms that can be invoked within a shader program and for which there is no need to add a [Uniform](uniform.md) field. To use them, simply declare them as `uniform` in your shader. For example, if you want to use the currently elapsed time, declare `uniform vec4 worldMatrix` and use the `worldMatrix` variable just like any other.
+Webots provides a set of useful uniforms that can be invoked within a shader program and for which there is no need to add a [Uniform](uniform.md) field. To use them, simply declare them as `uniform` in your shader. For example, if you wish to perform calculations in world space, declare `uniform vec4 worldMatrix` and use the `worldMatrix` variable to transform elements from model to world space.
 
 Here is a list of supported variables:
 


### PR DESCRIPTION
I had forgotten to add documentation on this additional feature.
Webots provides built-in uniforms for some matrices since the composed cube map feature, and while this feature will be extended, these three matrices are already given in the develop branch.