### PR TITLE
Update ROS version

### DIFF
--- a/guide/tutorial-7-using-ros.md
+++ b/guide/tutorial-7-using-ros.md
@@ -3,9 +3,8 @@
 This tutorial explains how to use the nodes from the `webots_ros` package
 provided with Webots.
 
-These examples were tested with ROS `kinetic`, `jade`, `indigo`, `hydro` and `groovy`
-distributions on Linux. There is no warranty they will work if you use a
-different platform or an ancient distribution of ROS.
+These examples were tested with ROS `kinetic` on Linux.
+There is no warranty they will work if you use a different platform or an ancient distribution of ROS.
 
 ### Installing ROS
 


### PR DESCRIPTION
Related to https://github.com/omichel/webots/pull/4528.

On Ubuntu 16.04 packages the default ROS version is `kinetic` and won't test with other versions.