### PR TITLE
Fix "notes" case

### DIFF
--- a/automobile/cpp-java-and-python-wrappers-of-the-automobile-libraries.md
+++ b/automobile/cpp-java-and-python-wrappers-of-the-automobile-libraries.md
@@ -9,7 +9,7 @@ used to define the method names. The `init` and `cleanup` functions are called
 automatically from the constructor/destructor of the
 [Driver](cpp-libraries.md#cppdriver) and [Car](cpp-libraries.md#cppcar) classes.
 
-> **note** [Java]:
+> **Note** [Java]:
 The following program shows how to set the cruising speed and the steering angle
 in Java:
 
@@ -30,7 +30,7 @@ in Java:
 > }
 > ```
 
-> **note** [Python]:
+> **Note** [Python]:
 The following program shows how to set the cruising speed and the steering angle
 in Python:
 

--- a/automobile/driver-library.md
+++ b/automobile/driver-library.md
@@ -228,7 +228,7 @@ double wbu_driver_get_rpm();
 
 This function returns the estimation of the engine rotation speed.
 
-> **note**:
+> **Note**:
 If the control in cruising speed is enabled, this function returns an error
 because there is no engine model when control in cruising speed is enabled.
 
@@ -304,7 +304,7 @@ of the `Car` PROTO, the output torque is:
 output_torque = c * rpm^2 + b * rpm + a
 ```
 
-> **note**:
+> **Note**:
 if the rpm is below the `engineMinRPM` parameter of the [Car](car.md) PROTO,
 `engineMinRPM` is used instead of the real rpm, but if the rpm is above the
 `engineMaxRPM` parameter, then the output torque is 0.

--- a/automobile/ros-support.md
+++ b/automobile/ros-support.md
@@ -6,6 +6,6 @@ In order to access all the services corresponding to the functions of the
 topics descriptions in the [ros\_automobile
 controller](ros_automobile-controller.md#ros_automobile_messages) section.
 
-> **note**:
+> **Note**:
 You will need to copy the automobile service files in your catkin workspace and
 add them to the "CmakeList.txt" to be able to use them.

--- a/automobile/ros_automobile-controller.md
+++ b/automobile/ros_automobile-controller.md
@@ -43,7 +43,7 @@ available with the `ros_automobile` controller.
 | [/automobile/set\_steering\_angle](driver-library.md#wbu_driver_set_steering_angle)                                                                                                                                                                                                                                                                              | service       | webots\_ros::automobile\_set\_steering\_angle                | float64 angle<br/>---<br/>int8 success                                                                                                        |
 | [/automobile/set\_throttle](driver-library.md#wbu_driver_set_throttle)                                                                                                                                                                                                                                                                                           | service       | webots\_ros::automobile\_set\_throttle                       | float64 throttle<br/>---<br/>int8 success                                                                                                     |
 
-> **note**:
+> **Note**:
 To enable synchronous simulation you will have to call the `/robot/time_step`
 service with a positive `step` argument. Then each time this service is called a
 car step will be executed (set the `step` argument to 0 to disable

--- a/automobile/scenario-creation-tutorial.md
+++ b/automobile/scenario-creation-tutorial.md
@@ -14,10 +14,10 @@ We will use a part of the OpenStreetMap map to generate the Webots world file. T
 
 As explained in the [OpenStreetMap importer](openstreetmap-importer.md) section, you should use the previously downloaded map to generate the Webots world.
 
-> **note**:
+> **Note**:
 This importer uses splines to improve and smooth the path of the roads, unfortunately the OpenStreetMap to SUMO importer does not support this, it is therefore recommended to disable it (setting the spline subdivision to 0) if you want then to add traffic using SUMO.
 
-> **note**:
+> **Note**:
 It is strongly recommended to not use the 3D feature of the [OpenStreetMap importer](openstreetmap-importer.md) otherwise it will not be possible to add traffic using SUMO.
 
 Once the conversion is complete, the importer will display the number of objects generated, the map offset, the reference coordinates and the projection used:
@@ -48,7 +48,7 @@ We can also use the previously downloaded map to generate the SUMO network file.
 netconvert --osm-files map.osm -o sumo.net.xml --geometry.remove --roundabouts.guess --ramps.guess --junctions.join --osm.railway.oneway-default --tls.guess-signals --tls.discard-simple --tls.join --proj "projection parameters"
 ```
 
-> **note**:
+> **Note**:
 You will have to replace `map.osm` by the real name of your map and `longitude_value` and `latitude_value` by the values displayed previously by the [OpenStreetMap importer](openstreetmap-importer.md).
 
 Both the [OpenStreetMap importer](openstreetmap-importer.md) and [netconvert](http://sumo.dlr.de/wiki/NETCONVERT) will center the map, but it can happen that the centering is not perfectly matched and results in an offset between the Webots world and the SUMO network. To fix this problem, simply open the `sumo.net.xml` in a text editor and look for the line starting by `<location netOffset=` (it should be at the beginning of the file). You will need to change the value of the `netOffset` field, the new value (for each component) should be the previous value additioned to the value of `x_offset_value` and `y_offset_value` displayed by the [OpenStreetMap importer](openstreetmap-importer.md).

--- a/automobile/sumo-interface.md
+++ b/automobile/sumo-interface.md
@@ -7,7 +7,7 @@ a large number of vehicles in real-time. This interface is written in python in
 a supervisor controller and uses  [TraCI](http://sumo.dlr.de/wiki/TraCI) to
 communicate with SUMO.
 
-> **note**:
+> **Note**:
 Currently version 0.27.1 of SUMO is distributed with Webots.
 
 In order to use this interface a few rules need to be observed. First, a
@@ -66,7 +66,7 @@ field `controllerArgs` in order to customize the behavior of the interface:
 %end
 
 
-> **note** [Mac OS X]:
+> **Note** [Mac OS X]:
 On Mac OS X, SUMO relies on X11. You need therefore to install [XQuartz](https://www.xquartz.org) (version 2.7.8 or later) for the interface to work.
 
 

--- a/reference/accelerometer.md
+++ b/reference/accelerometer.md
@@ -85,7 +85,7 @@ axis. Note that the gravity can be specified in the `gravity` field in the
 this offset must be subtracted. The device's output will be zero during free
 fall when no offset is substracted.
 
-> **note** [C, C++]:
+> **Note** [C, C++]:
 The returned vector is a pointer to the internal values managed by the
 [Accelerometer](#accelerometer) node, therefore it is illegal to free this
 pointer. Furthermore, note that the pointed values are only valid until the next
@@ -94,5 +94,5 @@ longer period they must be copied.
 
 <!-- -->
 
-> **note** [Python]:
+> **Note** [Python]:
 `getValues()` returns the 3D-vector as a list containing three floats.

--- a/reference/camera.md
+++ b/reference/camera.md
@@ -138,7 +138,7 @@ function. The format of this buffers is BGRA (32 bits). We recommend to use the
 `wb_camera_image_get_*`-like functions to access the buffer because the internal
 format could change.
 
-> **note** [Matlab]:
+> **Note** [Matlab]:
 The Matlab API uses a language-specific representation of color images
 consisting of a 3D array of RGB triplets. Please look at the [Matlab
 example](#wb_camera_get_image) in the `wb_camera_get_image` function's
@@ -402,7 +402,7 @@ for (int x = 0; x < image_width; x++)
   }
 ```
 
-> **note** [Java]:
+> **Note** [Java]:
 `Camera.getImage()` returns an array of int (`int[]`). The length of this array
 corresponds to the number of pixels in the image, that is the width multiplied
 by the height of the image. Each `int` element of the array represents one pixel
@@ -427,7 +427,7 @@ an `int` color/gray component in the range [0..255]. Here is an example:
 
 <!-- -->
 
-> **note** [Python]:
+> **Note** [Python]:
 `getImage()` returns a `string`. This `string` is closely related to the `const
 char *` of the C API. `imageGet*`-like functions can be used to get the channels
 of the camera Here is an example:
@@ -458,7 +458,7 @@ directly used for accessing to the pixels. Here is an example:
 
 <!-- -->
 
-> **note** [Matlab]:
+> **Note** [Matlab]:
 `wb_camera_get_image()` returns a 3-dimensional array of `uint(8)`. The first
 two dimensions of the array are the width and the height of camera's image, the
 third being the RGB code: 1 for red, 2 for blue and 3 for green.

--- a/reference/compass.md
+++ b/reference/compass.md
@@ -113,7 +113,7 @@ return bearing;
 }
 ```
 
-> **note** [C, C++]:
+> **Note** [C, C++]:
 The returned vector is a pointer to the internal values managed by the
 [Compass](#compass) node, therefore it is illegal to free this pointer.
 Furthermore, note that the pointed values are only valid until the next call to
@@ -122,5 +122,5 @@ period they must be copied.
 
 <!-- -->
 
-> **note** [Python]:
+> **Note** [Python]:
 `getValues()` returns the vector as a list containing three floats.

--- a/reference/connector.md
+++ b/reference/connector.md
@@ -79,7 +79,7 @@ attraction state, or that a suction pump was activated, etc. But the actual
 physical link exists only if `wb_connector_lock()` was called when a compatible
 peer was present (or if the [Connector](#connector) was auto-locked).
 
-    > **note**:
+    > **Note**:
 If `Connectors` nodes are locked and correctly aligned (and compatible) in the
 .wbt file then the simulation will start with these connectors already attached
 by a physical link. You can take advantage of this feature to start your
@@ -189,7 +189,7 @@ connect.
 
 %end
 
-> **note**:
+> **Note**:
 To be functional, a [Connector](#connector) node requires the presence of a
 [Physics](physics.md) node in its parent node. But it is not necessary to add a
 [Physics](physics.md) node to the [Connector](#connector) itself.

--- a/reference/contactproperties.md
+++ b/reference/contactproperties.md
@@ -36,7 +36,7 @@ of the two colliding [Solid](solid.md)s. The values of the first matching
 matching node is found, default values are used. The default values are the same
 as those indicated above.
 
-> **note**:
+> **Note**:
 In older Webots versions, contact properties used to be specified in
 [Physics](physics.md) nodes. For compatibility reasons, contact properties
 specified like this are still functional in Webots, but they trigger deprecation
@@ -137,7 +137,7 @@ the linear velocity of the contact surface. The formulas affecting the gain and
 pitch of these sounds were determinated empirically to produce fairly realistic
 sounds. They are subject to improvements.
 
-> **note**:
+> **Note**:
 The youBot robot is a good example of asymmetric coulombFriction and
 forceDependentSlip, it is located in
 WEBOTS\_HOME/projects/robot/youbot/worlds/youbot.wbt.

--- a/reference/damping.md
+++ b/reference/damping.md
@@ -22,7 +22,7 @@ simulation, it directly affects the velocity of the body. The damping effect is
 applied after all forces have been applied to the bodies. Damping can be used to
 reduce simulation instability.
 
-> **note**:
+> **Note**:
 When several rigidly linked [Solid](solid.md)s are merged (see
 [Physics](physics.md)'s [solid
 merging](physics.md#implicit-solid-merging-and-joints) section) damping values

--- a/reference/def-and-use.md
+++ b/reference/def-and-use.md
@@ -15,7 +15,7 @@ it in the ".wbt" or ".proto" file.
 USE defName
 ```
 
-> **note**:
+> **Note**:
 Although it is permitted to name any node using the DEF keyword, USE statements
 are not allowed for `Solid`, `Joint`, `JointParameters`, and
 `BallJointParameters` nodes and their derived nodes. Indeed, the ability for

--- a/reference/display.md
+++ b/reference/display.md
@@ -169,7 +169,7 @@ formula.
 
 In addition to these fonts, it is possible to add other TrueType fonts file in your `PROJECT_HOME/fonts` directory.
 
-> **note** [Matlab]:
+> **Note** [Matlab]:
 In the Matlab version of `wb_display_set_color()` the `color` argument must be a
 vector containing the three RGB components: `[RED GREEN BLUE]`. Each component
 must be a value between 0.0 and 1.0. For example the vector `[1 0 1]` represents
@@ -263,7 +263,7 @@ of outlined.
 polygon drawn by the `wb_display_draw_polygon()` function except that it is
 filled instead of outlined.
 
-> **note** [Java, Python, Matlab]:
+> **Note** [Java, Python, Matlab]:
 The Java, Python and Matlab equivalent of `wb_display_draw_polygon()` and
 `wb_display_fill_polygon()` don't have a `size` argument because in these
 languages the size is determined directly from the `x` and `y` arguments.
@@ -336,7 +336,7 @@ specified by the `ir` parameter. After this call the value of `ir` becomes
 invalid and should not be used any more. Using this function is recommended
 after a clipboard image is not needed any more.
 
-> **note** [Java]:
+> **Note** [Java]:
 The `Display.imageNew()` function can display the image returned by the
 `Camera.getImage()` function directly if the pixel format argument is set to
 ARGB.

--- a/reference/distancesensor.md
+++ b/reference/distancesensor.md
@@ -189,7 +189,7 @@ the paint color applied on the object with the [Pen](pen.md) device. Then, the
 distance value computed by the simulator is divided by the reflection factor
 before the lookup table is used to compute the output value.
 
-> **note**:
+> **Note**:
 Unlike other distance sensor rays, "infra-red" rays can detect solid parts of
 the robot itself. It is thus important to ensure that no solid geometries
 interpose between the sensor and the area to inspect.

--- a/reference/emitter.md
+++ b/reference/emitter.md
@@ -83,7 +83,7 @@ are used.
 total number of bytes in the packets enqueued in the emitter cannot exceed this
 number. A `bufferSize` of -1 (the default) is regarded as unlimited buffer size.
 
-> **note**:
+> **Note**:
 [Emitter](#emitter) nodes can also be used to communicate with the physics
 plugin (see [this chapter](physics-plugin.md)). In this case the channel must be
 set to 0 (the default). In addition it is highly recommended to choose -1 for
@@ -133,7 +133,7 @@ double array[5] = { 3.0, x, y, -1/z, -5.5 };
 wb_emitter_send(tag, array, 5 * sizeof(double));
 ```
 
-> **note** [Python]:
+> **Note** [Python]:
 The `send()` function sends a string. For sending primitive data types into this
 string, the *struct* module can be used. This module performs conversions
 between Python values and C structs represented as Python strings. Here is an
@@ -148,7 +148,7 @@ example:
 
 <!-- -->
 
-> **note** [Java]:
+> **Note** [Java]:
 The Java `send()` method does not have a `size` argument because the size is
 implicitly passed with the `data` argument. Here is an example of sending a Java
 string in a way that is compatible with a C string, so that it can be received
@@ -190,7 +190,7 @@ emitter can selectively send data to different receivers. The
 `wb_emitter_get_channel()` function returns the current channel number of the
 emitter.
 
-> **note** [C++, Java, Python]:
+> **Note** [C++, Java, Python]:
 In the oriented-object APIs, the WB\_CHANNEL\_BROADCAST constant is available as
 static integer of the [Emitter](#emitter) class (Emitter::CHANNEL\_BROADCAST).
 

--- a/reference/gps.md
+++ b/reference/gps.md
@@ -100,7 +100,7 @@ GPS.
 The `wb_gps_get_speed()` function returns the current [GPS](#gps) speed in
 meters per second.
 
-> **note** [C, C++]:
+> **Note** [C, C++]:
 The returned vector is a pointer to the internal values managed by the
 [GPS](#gps) node, therefore it is illegal to free this pointer. Furthermore,
 note that the pointed values are only valid until the next call to
@@ -109,7 +109,7 @@ period they must be copied.
 
 <!-- -->
 
-> **note** [Python]:
+> **Note** [Python]:
 `getValues()` returns the 3D-vector as a list containing three floats.
 
 ---
@@ -152,11 +152,11 @@ const char * wb_gps_convert_to_degrees_minutes_seconds(double decimal_degrees);
 This function converts a decimal degrees coordinate into a string representing
 the coordinate in the degrees minutes seconds format.
 
-> **note**:
+> **Note**:
 Your system should support UTF-8 otherwise you may get strange characters
 instead of the degree, minute and second symbols.
 
 <!-- -->
 
-> **note** [C]:
+> **Note** [C]:
 The returned string should be deallocated by the user.

--- a/reference/gyro.md
+++ b/reference/gyro.md
@@ -73,7 +73,7 @@ represents the angular velocity about one of the axes of the [Gyro](#gyro) node,
 expressed in radians per second [rad/s]. The first element corresponds to the
 angular velocity about the *x*-axis, the second element to the *y*-axis, etc.
 
-> **note** [C, C++]:
+> **Note** [C, C++]:
 The returned vector is a pointer to the internal values managed by the
 [Gyro](#gyro) node, therefore it is illegal to free this pointer. Furthermore,
 note that the pointed values are only valid until the next call to
@@ -82,5 +82,5 @@ period they must be copied.
 
 <!-- -->
 
-> **note** [Python]:
+> **Note** [Python]:
 `getValues()` returns the vector as a list containing three floats.

--- a/reference/hinge2joint.md
+++ b/reference/hinge2joint.md
@@ -31,7 +31,7 @@ and (default) zero suspension.
 Typically, [Hinge2Joint](#hinge2joint) can be used to model a steering wheel
 with suspension for a car, a shoulder or a hip for a humanoid robot.
 
-> **note**:
+> **Note**:
 A [Hinge2Joint](#hinge2joint) will connect only [Solid](solid.md)s having a
 [Physics](physics.md) node. In other words, this joint cannot be statically
 based.

--- a/reference/immersionproperties.md
+++ b/reference/immersionproperties.md
@@ -76,7 +76,7 @@ exerted by the fluid on the solid according the following formulas
     linear nature it may offer a better numerical stability than the above quadratic
     drags when the immersed solids are subject to large external forces or torques.
 
-> **note**:
+> **Note**:
 The "xyz-projected area" computation mode is implemented only for
 boundingObjects that contain fully or partially immersed [Box](box.md) nodes,
 fully immersed [Cylinder](cylinder.md), [Capsule](capsule.md) and

--- a/reference/inertialunit.md
+++ b/reference/inertialunit.md
@@ -34,7 +34,7 @@ of elemental rotations denoted by YZX. The reference frame is made of the unit
 vector giving the north direction, the opposite of the normalized gravity vector
 and their cross-product (see [WorldInfo](worldinfo.md) to customize this frame).
 
-> **note**:
+> **Note**:
 In a gimbal lock situation, i.e., when the pitch is -π/2 or π/2, the roll and
 the yaw are set to NaN (Not a Number).
 
@@ -124,7 +124,7 @@ when the [InertialUnit](#inertialunit)'s *x*-axis is aligned with the north
 direction, it is π/2 when the unit is heading east, and -π/2 when the unit is
 oriented towards the west. The *yaw* angle can be used as a compass.
 
-> **note** [C, C++]:
+> **Note** [C, C++]:
 The returned vector is a pointer to internal values managed by the Webots,
 therefore it is illegal to free this pointer. Furthermore, note that the pointed
 values are only valid until the next call to `wb_robot_step()` or
@@ -133,5 +133,5 @@ copied.
 
 <!-- -->
 
-> **note** [Python]:
+> **Note** [Python]:
 `getRollPitchYaw()` returns the angles as a list containing three floats.

--- a/reference/jointparameters.md
+++ b/reference/jointparameters.md
@@ -12,7 +12,7 @@ JointParameters {
 }
 ```
 
-> **note**:
+> **Note**:
 The default value of the axis field may change in a derived class. For instance,
 the axis default value of an [HingeJointParameters](hingejointparameters.md) is
 `1 0 0`.

--- a/reference/joystick.md
+++ b/reference/joystick.md
@@ -4,7 +4,7 @@ The [Joystick](#joystick) API doesn't correspond to a Webots node. It is a set o
 
 Each physical joystick can be used by one controller at a time only. If several joysticks are connected, different controllers may be able to use a different joystick.
 
-> **note**:
+> **Note**:
 In C++, Python and Java the joystick functions are in a dedicated class called
 `Joystick`. In order to get the `Joystick` instance, you should call the
 `getJoystick()` function of the `Robot` class.
@@ -124,5 +124,5 @@ The `wb_joystick_set_auto_centering_gain()` function sets the auto-centering gai
 
 The `wb_joystick_set_resistance_gain()` function sets the resistance gain of the force feedback. Resistance is an effect that tend to prevent the axis from moving. The joystick must support force feedback and the unit of `gain` is hardware specific.
 
-> **note**:
+> **Note**:
 The units of the force feedback (both the level and gain) are hardware specific, it is therefore recommended to try first with a small value in order to avoid instabilities.

--- a/reference/keyboard.md
+++ b/reference/keyboard.md
@@ -4,7 +4,7 @@ The [Keyboard](#keyboard) is not a node, it is a set of functions available by
 default for each [Robot](robot.md) node to read the keyboard input. It is
 therefore not a device and the functions do not require any `WbDeviceTag`.
 
-> **note** [Python]:
+> **Note** [Python]:
 In C++, Python and Java the keyboard functions are in a dedicated class called
 `Keyboard`. In order to get the `Keyboard` instance, you should call the
 `getKeyboard()` function of the `Robot` class.
@@ -51,14 +51,14 @@ simultaneously pressed. The function can be called up to 7 times to detect up to
 7 simultaneous keys pressed. The `wb_keyboard_disable()` function should be used
 to stop the keyboard readings.
 
-> **note** [C++]:
+> **Note** [C++]:
 The keyboard predefined values are located into a (static) enumeration of the
 Keyboard class. For example, `Keyboard.CONTROL` corresponds to the
 *Control* key stroke.
 
 <!-- -->
 
-> **note** [Java]:
+> **Note** [Java]:
 The keyboard predefined values are final integers located in the Keyboard class.
 For example, *Ctrl+B* can be tested like this:
 
@@ -70,7 +70,7 @@ For example, *Ctrl+B* can be tested like this:
 
 <!-- -->
 
-> **note** [Python]:
+> **Note** [Python]:
 The keyboard predefined values are integers located into the Keyboard class. For
 example, *Ctrl+B* can be tested like this:
 

--- a/reference/lidar.md
+++ b/reference/lidar.md
@@ -70,10 +70,10 @@ The X, Y and Z coordinates are relative to the [Lidar](#lidar) node origin. The
 point was acquired. With lidar devices, all the points are not acquired at the
 exact same time but rather sequentially.
 
-> **note** [C++]:
+> **Note** [C++]:
 In C++ the name of the structure is `LidarPoint`.
 
-> **note** [Java/Python]:
+> **Note** [Java/Python]:
 In Java and Python, the structure is replaced by a class called `LidarPoint`.
 
 ### Field Summary
@@ -137,7 +137,7 @@ of the lidar.
 image. More information on compositors is provided in the
 [compositor](camera.md) field description of the [Camera](camera.md) node.
 
-> **note**:
+> **Note**:
 The fields `numberOfLayers`, `verticalFieldOfView`, `horizontalResolution` and
 `fieldOfView` should respect the following constraint in order to be able to
 simulate the lidar:
@@ -151,7 +151,7 @@ simulate the lidar:
 
 A lidar is said rotating if its `type` field is set to 'rotating'. In that case, the node inserted in the `rotatingHead` rotates along the Y axis at the frequency defined in the `defaultFrequency` field. This rotation starts as soon as the lidar is enabled. The internal depth camera is attached to this node and is therefore also rotating along the Y axis.
 
-> **note**:
+> **Note**:
 The internal depth camera is using a horizontal field of view defined in the `fieldOfView` field, but since it is rotating, the actual field of view is 2 * π.
 
 ### Lidar Functions
@@ -207,7 +207,7 @@ cloud update.
 The `wb_lidar_is_point_cloud_enabled()` function returns true if the point cloud
 update is enabled or false otherwise.
 
-> **note**:
+> **Note**:
 To get the point cloud array, enabling the point cloud is not sufficient. First the lidar should be enabled using the `wb_lidar_enable()` function.
 
 ---
@@ -246,7 +246,7 @@ Attempting to read outside the bounds of this memory chunk will cause an error.
 The `wb_lidar_get_layer_range_image()` function is a convenient way of getting
 directly the sub range image associated with one layer.
 
-> **note** [Python]:
+> **Note** [Python]:
 The Lidar class has two methods for getting the lidar image. The
 `getRangeImage()` returns a one-dimensional list of floats, while the
 `getRangeImageArray()` returns a two-dimensional list of floats. Their content

--- a/reference/lightsensor.md
+++ b/reference/lightsensor.md
@@ -159,7 +159,7 @@ Like any other type of collision detection in Webots, the
 if it has a visible geometric structure, a [Solid](solid.md) node cannot produce
 any occlusion if its `boundingObject` is not specified.
 
-> **note**:
+> **Note**:
 The default value of the `attenuation` field of [PointLight](pointlight.md)s and
 [SpotLight](spotlight.md)s is *1 0 0*. These values correspond to the VRML
 default, and are not appropriate for modeling the attenuation of a real lights.
@@ -175,7 +175,7 @@ world should be achieved.
 
 <!-- -->
 
-> **note**:
+> **Note**:
 If the calibration data for the `lookupTable` was obtained in lux (lx) or lumens
 per square meter (lm/m^2) instead of W/m^2, it makes sense to substitute the
 radiometry terms and units in this document with their photometry equivalents:

--- a/reference/motion.md
+++ b/reference/motion.md
@@ -28,7 +28,7 @@ playback.
 The `wbu_motion_delete()` function frees all the memory associated with the
 `WbMotionRef`. This `WbMotionRef` can no longer be used afterwards.
 
-> **note** [C++, Java, Python]:
+> **Note** [C++, Java, Python]:
 The constructor and destructor of the Motion class are used instead of
 `wbu_motion_new()` and `wbu_motion_delete()`. In these languages, an error
 condition can be detected by calling the `isValid()` function after the

--- a/reference/motor.md
+++ b/reference/motor.md
@@ -161,7 +161,7 @@ by the `basicTimeStep` field of the [WorldInfo](worldinfo.md) node (converted in
 seconds), and *A* is the acceleration of the motor as specified by the
 `acceleration` field (default) or set with `wb_motor_set_acceleration()`.
 
-> **note**:
+> **Note**:
 *error_integral* and *previous_error* are both reset to *0* after every call of
 `wb_motor_set_control_pid()`.
 
@@ -252,7 +252,7 @@ Similarly, for a linear motor it is computed according to the following equation
 
 Where `output_torque` is the value returned by the [wb\_motor\_get\_torque\_feedback](#wb_motor_get_torque_feedback) function, `output_force` is the value returned by the [wb\_motor\_get\_force\_feedback](#wb_motor_get_force_feedback) function and `consumptionFactor` is a constant provided by the `consumptionFactor` field of the [Motor](motor.md) node.
 
-> **note**:
+> **Note**:
 This is a very simplified model for the energy consumption of an electrical motor, but it is sufficient for most prototyping purposes. If a more specific or accurate model is needed, it can be implemented in the robot controller itself.
 
 ### Motor Functions
@@ -324,22 +324,22 @@ wb_motor_set_position(tag, INFINITY);
 wb_motor_set_velocity(tag, desired_speed);  // rad/s
 ```
 
-> **note** [C++]:
+> **Note** [C++]:
 In C++ use `std::numeric_limits<double>::infinity()` instead of INFINITY
 
 <!-- -->
 
-> **note** [Java]:
+> **Note** [Java]:
 In Java use `Double.POSITIVE_INFINITY` instead of INFINITY
 
 <!-- -->
 
-> **note** [Python]:
+> **Note** [Python]:
 In Python use `float('+inf')` instead of INFINITY
 
 <!-- -->
 
-> **note** [Matlab]:
+> **Note** [Matlab]:
 In MATLAB use `inf` instead of INFINITY
 
 The `wb_motor_get_target_position()` function allows the user to get the target

--- a/reference/pen.md
+++ b/reference/pen.md
@@ -44,13 +44,13 @@ An example of a textured floor used with a robot equipped with a pen is given in
 the "pen.wbt" example world (located in the "projects/samples/devices/worlds"
 directory of Webots).
 
-> **note**:
+> **Note**:
 The `inkEvaporation` field of the [WorldInfo](worldinfo.md) node controls how
 fast the ink evaporates (disappears).
 
 <!-- -->
 
-> **note**:
+> **Note**:
 The drawings performed by a pen can be seen by infra-red distance sensors.
 Hence, it is possible to implement a robotics experiment where a robot draws a
 line on the floor with a pen and a second robot performs a line following
@@ -128,7 +128,7 @@ wb_pen_set_ink_color(pen,0xF01010,0.9);
 The above statement will change the ink color of the indicated pen to some red
 color.
 
-> **note** [Matlab]:
+> **Note** [Matlab]:
 In the Matlab version of `wb_pen_set_ink_color()`, the `color` argument must be
 a vector containing the three RGB components: `[RED GREEN BLUE]`. Each component
 must be a value between 0.0 and 1.0. For example the vector `[1 0 1]` represents

--- a/reference/physics.md
+++ b/reference/physics.md
@@ -24,7 +24,7 @@ node derived from [Solid](solid.md)). The presence or absence of a
 [Physics](#physics) node in the `physics` field of a [Solid](solid.md) defines
 whether the [Solid](solid.md) will have a *physics* or a *kinematic* behavior.
 
-> **note**:
+> **Note**:
 In older Webots versions, `coulombFriction, bounce, bounceVelocity` and
 `forceDependentSlip` fields used to be specified in [Physics](#physics) nodes.
 Now these values must be specified in [ContactProperties](contactproperties.md)
@@ -124,7 +124,7 @@ grasping robotic hand or gripper is crucial for the simulation of such devices.
 Therefore the mechanical body parts of robots (eg., legs, wheels, arms, hands,
 etc) need in general to have [Physics](#physics) nodes.
 
-> **note**:
+> **Note**:
 It is possible to set the `physics` field of a [Robot](robot.md) or a top
 [Solid](solid.md) to `NULL` in order to pin its base to the static environment.
 This can be useful for the simulation of a robot arm whose base segment is
@@ -135,7 +135,7 @@ have no [Physics](#physics) nodes.
 
 <!-- -->
 
-> **note**:
+> **Note**:
 The [DifferentialWheels](differentialwheels.md) robot is a special case: it can
 move even if it does not have [Physics](#physics) nodes. That's because Webots
 uses a special *kinematics* algorithm for
@@ -161,7 +161,7 @@ just before the highest ancestor without [Physics](#physics) node. This way
 modelling a rigid assembly of [Solid](solid.md)s won't hurt physics simulation
 speed even if it aggregates numerous components.
 
-> **note**:
+> **Note**:
 When solid merging applies, only the highest ancestor of the rigid assembly has
 a body (a non null `dBodyID` in ODE terms) which holds the physical properties
 of the assembly. This may impact the way you design a [physics
@@ -307,7 +307,7 @@ volume in the simulated robot. This is true for these devices:
 [LED](led.md), [LightSensor](lightsensor.md), [Pen](pen.md), and
 [Receiver](receiver.md).
 
-> **note**:
+> **Note**:
 The [InertialUnit](inertialunit.md) and [Connector](connector.md) nodes work
 differently. Indeed, they require the presence of a [Physics](#physics) node in
 their parent node to be functional. It is also possible to specify a

--- a/reference/radar.md
+++ b/reference/radar.md
@@ -51,10 +51,10 @@ The `distance` is the radial distance between the radar and the target. The
 of the target relative to the radar sensor. The `azimuth` is the horizontal
 angle of the target relative to the radar.
 
-> **note** [C++]:
+> **Note** [C++]:
 In C++ the name of the structure is `RadarTarget`.
 
-> **note** [Java/Python]:
+> **Note** [Java/Python]:
 In Java and Python, the structure is replaced by a class called `RadarTarget`.
 
 ### Field Summary

--- a/reference/rangefinder.md
+++ b/reference/rangefinder.md
@@ -232,7 +232,7 @@ range value, directly from its pixel coordinates. The `range_finder_width`
 parameter can be obtained from the `wb_range_finder_get_width()` function. The
 `x` and `y` parameters are the coordinates of the pixel in the image.
 
-> **note** [Python]:
+> **Note** [Python]:
 The RangeFinder class has two methods for getting the range-finder image. The
 `getRangeImage()` returns a one-dimensional list of floats, while the
 `getRangeImageArray()` returns a two-dimensional list of floats. Their content

--- a/reference/receiver.md
+++ b/reference/receiver.md
@@ -160,7 +160,7 @@ long as emitters and receivers agree.
 
 %end
 
-> **note**:
+> **Note**:
 Webots' Emitter/Receiver API guarantees that:
 
 - Packets will be received in the same order they were sent
@@ -212,7 +212,7 @@ equal to the *size* argument of the corresponding `emitter_send_packet()` call.
 It is illegal to call `wb_receiver_get_data_size()` when the queue is empty
 (`wb_receiver_get_queue_length()` == 0).
 
-> **note** [Python]:
+> **Note** [Python]:
 The `getData()` function returns a string. Similarly to the `sendPacket()`
 function of the [Emitter](emitter.md) device, using the functions of the struct
 module is recommended for sending primitive data types. Here is an example for
@@ -227,7 +227,7 @@ getting the data:
 
 <!-- -->
 
-> **note** [Matlab]:
+> **Note** [Matlab]:
 The Matlab `wb_receiver_get_data()` function returns a MATLAB *libpointer*. The
 receiving code is responsible for extracting the data from the *libpointer*
 using MATLAB's `setdatatype()` and `get()` functions. Here is an example on how
@@ -312,7 +312,7 @@ If the packet is sent from a physics plugin, the returned values will be NaN (No
 The returned vector is valid only until the next call to `wb_receiver_next_packet()`.
 It is illegal to call this function if the receiver's queue is empty (`wb_receiver_get_queue_length()` == 0).
 
-> **note** [Python]:
+> **Note** [Python]:
 `getEmitterDirection()` returns the vector as a list containing three floats.
 
 ---
@@ -342,7 +342,7 @@ channels.
 The `wb_receiver_get_channel()` function returns the current channel number of
 the receiver.
 
-> **note** [C++, Java, Python]:
+> **Note** [C++, Java, Python]:
 In the oriented-object APIs, the WB\_CHANNEL\_BROADCAST constant is available as
 static integer of the [Receiver](#receiver) class
 (Receiver::CHANNEL\_BROADCAST).

--- a/reference/robot.md
+++ b/reference/robot.md
@@ -65,7 +65,7 @@ two remain constant. *Important:* when the current energy value reaches zero,
 the corresponding controller process terminates and the simulated robot stops
 all motion.
 
-> **note**:
+> **Note**:
 *[J]=[V].[A].[s] and [J]=[V].[A.h]/3600*
 
 - `cpuConsumption`: power consumption of the CPU (central processing unit) of the
@@ -309,7 +309,7 @@ identifier will be used subsequently for enabling, sending commands to, or
 reading data from this device. If the specified device is not found, the
 function returns 0.
 
-> **note**:
+> **Note**:
 This function is not available in the C++, Java and Python APIs. Instead, C++, Java and Python users should use device specific typed methods (see below).
 
 
@@ -360,7 +360,7 @@ function `getDistanceSensor` will return a reference to a
 found, the function returns `NULL` in C++, `null` in Java or the `none` in
 Python.
 
-> **note**:
+> **Note**:
 These functions are not available in the C and MATLAB APIs. Instead, C and Matlab users should use [wb\_robot\_get\_device](#wb_robot_get_device).
 
 **See also**
@@ -821,7 +821,7 @@ void *wbw_robot_window_custom_function(void *arg) {
 }
 ```
 
-> **note** [Java, Python, Matlab]:
+> **Note** [Java, Python, Matlab]:
 Given that the robot window can only be implemented for C/C++ controllers,
 `wb_robot_window_custom_function` is not available in Java, Phyton or Matlab
 API.

--- a/reference/servo.md
+++ b/reference/servo.md
@@ -1,6 +1,6 @@
 ## Servo
 
-> **note**:
+> **Note**:
 As of Webots 7.2.0, the [Servo](#servo) node is deprecated and should not be
 used in any new simulation models. It is kept for backwards compatibility only.
 The functionality of the [Servo](#servo) node is replaced by the one provided by
@@ -522,22 +522,22 @@ wb_servo_set_position(tag, INFINITY);
 wb_servo_set_velocity(tag, desired_speed);  // rad/s
 ```
 
-> **note** [C++]:
+> **Note** [C++]:
 In C++ use `std::numeric_limits<double>::infinity()` instead of INFINITY
 
 <!-- -->
 
-> **note** [Java]:
+> **Note** [Java]:
 In Java use `Double.POSITIVE_INFINITY` instead of INFINITY
 
 <!-- -->
 
-> **note** [Python]:
+> **Note** [Python]:
 In Python use `float('+inf')` instead of INFINITY
 
 <!-- -->
 
-> **note** [Matlab]:
+> **Note** [Matlab]:
 In MATLAB use `inf` instead of INFINITY
 
 The `wb_servo_get_target_position()` function allows the user to get the target

--- a/reference/shape.md
+++ b/reference/shape.md
@@ -29,7 +29,7 @@ applied.
 - The `castShadows` field allows the user to turn on (TRUE) or off (FALSE) shadows
 casted by this shape.
 
-> **note**:
+> **Note**:
 Objects cast shadows only if the world contains at least one [Light](light.md)
 node with `castShadows` field set to TRUE and if shadows are not disabled in the
 application preferences.

--- a/reference/speaker.md
+++ b/reference/speaker.md
@@ -33,7 +33,7 @@ The `sound` argument specifies the path to the wave file that should be played. 
 
 It is possible to change the volume, pitch, balance, and loop parameters of a sound currently playing by calling again the `wb_speaker_play_sound` function with the same speakers and `sound` arguments.
 
-> **note**:
+> **Note**:
 The path to the sound file should be defined either absolutely or relatively. If defined relatively, it will be searched first relatively to the robot controller folder. If not found there and if the robot is a PROTO, it will be searched relatively to the PROTO folder of the robot.
 
 ---

--- a/reference/structure-of-ode-objects.md
+++ b/reference/structure-of-ode-objects.md
@@ -25,7 +25,7 @@ information shall be useful for implementing physics plugins.
 
 %end
 
-> **note**:
+> **Note**:
 Although a physics plugin grants you access to the dGeomIDs created and managed
 by Webots, you should never attempt to set a user-defined data pointer by means
 of dGeomSetData() for these dGeomIDs as Webots stores its own data pointer in

--- a/reference/supervisor.md
+++ b/reference/supervisor.md
@@ -17,7 +17,7 @@ If a [Supervisor](#supervisor) contains devices then the
 [Supervisor](#supervisor) controller can use them. Webots PRO is required to use
 the [Supervisor](#supervisor) node.
 
-> **note**:
+> **Note**:
 Note that in some special cases the [Supervisor](#supervisor) functions might
 return wrong values and it might not be possible to retrieve fields and nodes.
 This occurs when closing a world and quitting its controllers, i.e. reverting
@@ -27,7 +27,7 @@ string, an empty string is returned instead of a NULL pointer.
 
 <!-- -->
 
-> **note** [C++, Java, Python]:
+> **Note** [C++, Java, Python]:
 It is a good practice to check for a NULL pointer after calling a
 [Supervisor](#supervisor) function.
 
@@ -171,7 +171,7 @@ corresponding to the base type name of the node, like "DifferentialWheels",
 "Appearance", "LightSensor", etc. If the argument is NULL, the function returns
 NULL.
 
-> **note** [C++, Java, Python]:
+> **Note** [C++, Java, Python]:
 In the oriented-object APIs, the WB\_NODE\_* constants are available as static
 integers of the `Node` class (for example, Node::DIFFERENTIAL\_WHEELS). These
 integers can be directly compared with the output of the `Node::getType()`
@@ -217,7 +217,7 @@ belongs to. It can be a single field (SF) or a multiple field (MF). If no such
 field name exists for the specified node or the field is an internal field of a
 PROTO, the return value is NULL. Otherwise, it returns a handler to a field.
 
-> **note**:
+> **Note**:
 The `wb_supervisor_node_get_field()` function will return a valid field handler
 if the field corresponding to the field name is an hidden field.
 
@@ -282,7 +282,7 @@ this time with coordinates expressed in the global (world) coordinate system.
 The "WEBOTS\_HOME/projects/robots/ipr/worlds/ipr\_cube.wbt" project shows how to
 use these functions to do this.
 
-> **note**:
+> **Note**:
 The returned pointers are valid during one time step only as memory will be
 deallocated at the next time step.
 
@@ -312,7 +312,7 @@ always the zero vector.
 
 The "WEBOTS\_HOME/projects/samples/.wbt" project shows how to use this function.
 
-> **note**:
+> **Note**:
 The returned pointer is valid during one time step only as memory will be
 deallocated at the next time step.
 
@@ -347,7 +347,7 @@ values on the first 3 array components.
 The "WEBOTS\_HOME/projects/samples/howto/worlds/cylinder\_stack.wbt" project
 shows how to use this function.
 
-> **note**:
+> **Note**:
 The returned pointer is valid during one time step only as memory will be
 deallocated at the next time step.
 
@@ -548,7 +548,7 @@ supervisor_set_label(0,"hello universe",0,0,0.1,0xffff00,0,"Times New Roman");
 will change the label "hello world" defined earlier into "hello universe", using
 a yellow color for the new text.
 
-> **note** [Matlab]:
+> **Note** [Matlab]:
 In the Matlab version of `wb_supervisor_set_label()` the `color` argument must
 be a vector containing the three RGB components: `[RED GREEN BLUE]`. Each
 component must be a value between 0.0 and 1.0. For example the vector `[1 0 1]`
@@ -739,7 +739,7 @@ path is used instead (e.g., a simple save operation). The boolean return value
 indicates the success of the save operation. Be aware that this function can
 overwrite silently existing files, so that the corresponding data may be lost.
 
-> **note** [C++, Java, Python, Matlab]:
+> **Note** [C++, Java, Python, Matlab]:
 In the other APIs, the `Robot.saveWorld()` function can be called without
 argument. In this case, a simple save operation is performed.
 
@@ -889,7 +889,7 @@ NULL is passed as an argument to this function, it returns -1. Hence, this
 function can also be used to test if a field is MF (like `WB_MF_INT32`) or SF
 (like `WB_SF_BOOL`).
 
-> **note** [C++, Java, Python]:
+> **Note** [C++, Java, Python]:
 In the oriented-object APIs, the WB\_*F\_* constants are available as static
 integers of the `Field` class (for example, Field::SF\_BOOL). These integers can
 be directly compared with the output of the `Field::getType()`
@@ -986,7 +986,7 @@ the item in the multiple field. The type of the field has to match with the name
 of the function used and the index should be comprised between minus the total
 number of items and the total number of items minus one, otherwise the value of the field remains unchanged (and a warning message is displayed). Using a negative index starts the count from the last element of the field until the first one. Index -1 represents the last item and the first item is represented by index 0 or minus number of items.
 
-> **note**:
+> **Note**:
 Since Webots 7.4.4, the inertia of a solid is no longer automatically reset when
 changing its translation or rotation using `wb_supervisor_field_set_sf_vec2f`
 and `wb_supervisor_field_set_sf_rotation` functions. If needed, the user has to
@@ -1066,7 +1066,7 @@ int main(int argc, char **argv) {
 The `wb_supervisor_field_remove_mf_node()` function removes a Webots node from
 an MF\_NODE (like if the node was manually removed from the scene tree).
 
-> **note**:
+> **Note**:
 Note that these functions are still limited in the actual Webots version. For
 example, a device imported into a Robot node doesn't reset the Robot, so the
 device cannot be get by using the `wb_robot_get_device()` function.

--- a/reference/transform.md
+++ b/reference/transform.md
@@ -66,7 +66,7 @@ automatically reset to *x x x*. The same holds for a `Transform` placed inside a
 of the previous constrained scale fields, the two others are actuated using the
 new value and the corresponding constraint rule.
 
-> **note**:
+> **Note**:
 If a `Transform` is named using the [DEF](def-and-use.md) keyword and later
 referenced inside a `boundingObject` with a USE statement, the constraint
 corresponding to its first `Geometry` descendant applies to the `scale` fields

--- a/reference/utility-functions.md
+++ b/reference/utility-functions.md
@@ -148,7 +148,7 @@ the received data. If `size` is non-NULL, it is set to the number of bytes of
 data available in the returned buffer. If multiple messages are sent to the
 physics plugin at the same time step, then they will be concatenated.
 
-> **note**:
+> **Note**:
 Pay attention when managing multiple concatenated string messages, because every
 message will terminate with the null character `\0` preventing the correct copy
 and display of the returned data. The following example shows how to split


### PR DESCRIPTION
Fix #189

The "notes" case is incoherent between the `guide | robotis-op2` and the `reference | autombile` books.
