### PR TITLE
Fix emply table header cells in Reference Manual

### DIFF
--- a/reference/differentialwheels.md
+++ b/reference/differentialwheels.md
@@ -128,7 +128,7 @@ initial elevation throughout the simulation.
 
 %figure "DifferentialWheels simulation modes"
 
-|                       | Physics mode       | Kinematics mode                    |
+| &nbsp;                | Physics mode       | Kinematics mode                    |
 | --------------------- | ------------------ | ---------------------------------- |
 | Motion triggered by   | Wheels friction    | 2d Webots kinematics               |
 | Friction simulation   | Yes, Coulomb model | No, robot slides against obstacles |

--- a/reference/servo.md
+++ b/reference/servo.md
@@ -98,7 +98,7 @@ expressed in *meters*. See [this table](#servo-units):
 
 %figure "Servo Units"
 
-|              | Rotational                   | Linear                    |
+| &nbsp;       | Rotational                   | Linear                    |
 | ------------ | ---------------------------- | ------------------------- |
 | Position     | rad (radians)                | m (meters)                |
 | Velocity     | rad/s (radians / second)     | m/s (meters / second)     |
@@ -233,7 +233,7 @@ used.
 
 %figure "Servo Control Summary"
 
-|                                | position control                 | velocity control                 | force control                         |
+| &nbsp;                         | position control                 | velocity control                 | force control                         |
 | ------------------------------ | -------------------------------- | -------------------------------- | ------------------------------------- |
 | uses P-controller              | yes                              | no                               | no                                    |
 | wb\_servo\_set\_position()     | * specifies the desired position | should be set to INFINITY        | switches to position/velocity control |


### PR DESCRIPTION
Empty cells are not correctly displayed in the Webots documentation (but works in the GitHub preview)