### PR TITLE
Enhancement enable geometric anti aliasing

### DIFF
--- a/guide/preferences.md
+++ b/guide/preferences.md
@@ -44,7 +44,7 @@ the least efficient one.
 on the 3D scene in Webots. This option can lead to reduced performance, but it improves 
 graphical fidelity significantly. It is disabled by default on systems that do not meet 
 our minimum requirements. Note that this option does not apply to any Camera rendering, 
-this is managed the `Disable camera anti-aliasing` setting in the same tab of the preferences dialog.
+this is managed by the `Disable camera anti-aliasing` setting in the same tab of the preferences dialog.
 
 - The `Disable shadows` option allows you to disable completely the shadows in the
 3D view and in the Camera rendering, whatever the values of the

--- a/guide/preferences.md
+++ b/guide/preferences.md
@@ -43,7 +43,7 @@ the least efficient one.
 - The `Main 3D View Anti-Aliasing` option allows you to enable Multisample Anti-Aliasing
 on the 3D Scene in Webots. This option can lead to reduced performance, but it improves 
 graphical fidelity significantly. It is disabled by default on systems that do not meet 
-our minimum requirements. Note that this option does not apply to any `Camera` rendering, 
+our minimum requirements. Note that this option does not apply to any Camera rendering, 
 this is managed by a separate setting in the same tab of the preferences dialog.
 
 - The `Disable shadows` option allows you to disable completely the shadows in the

--- a/guide/preferences.md
+++ b/guide/preferences.md
@@ -40,6 +40,12 @@ depending on the GPU OpenGL abilities.
 the Camera device images. The methods are sorted from the most efficient one to
 the least efficient one.
 
+- The `Main 3D View Anti-Aliasing` option allows you to enable Multisample Anti-Aliasing
+on the 3D Scene in Webots. This option can lead to reduced performance, but it improves 
+graphical fidelity significantly. It is disabled by default on systems that do not meet 
+our minimum requirements. Note that this option does not apply to any `Camera` rendering, 
+this is managed by a separate setting in the same tab of the preferences dialog.
+
 - The `Disable shadows` option allows you to disable completely the shadows in the
 3D view and in the Camera rendering, whatever the values of the
 *Light.castShadows* fields.

--- a/guide/preferences.md
+++ b/guide/preferences.md
@@ -44,7 +44,7 @@ the least efficient one.
 on the 3D Scene in Webots. This option can lead to reduced performance, but it improves 
 graphical fidelity significantly. It is disabled by default on systems that do not meet 
 our minimum requirements. Note that this option does not apply to any Camera rendering, 
-this is managed by a separate setting in the same tab of the preferences dialog.
+this is managed the `Disable camera anti-aliasing` setting in the same tab of the preferences dialog.
 
 - The `Disable shadows` option allows you to disable completely the shadows in the
 3D view and in the Camera rendering, whatever the values of the

--- a/guide/preferences.md
+++ b/guide/preferences.md
@@ -41,7 +41,7 @@ the Camera device images. The methods are sorted from the most efficient one to
 the least efficient one.
 
 - The `Main 3D View Anti-Aliasing` option allows you to enable Multisample Anti-Aliasing
-on the 3D Scene in Webots. This option can lead to reduced performance, but it improves 
+on the 3D scene in Webots. This option can lead to reduced performance, but it improves 
 graphical fidelity significantly. It is disabled by default on systems that do not meet 
 our minimum requirements. Note that this option does not apply to any Camera rendering, 
 this is managed the `Disable camera anti-aliasing` setting in the same tab of the preferences dialog.

--- a/guide/preferences.md
+++ b/guide/preferences.md
@@ -40,7 +40,7 @@ depending on the GPU OpenGL abilities.
 the Camera device images. The methods are sorted from the most efficient one to
 the least efficient one.
 
-- The `Main 3D View Anti-Aliasing` option allows you to enable Multisample Anti-Aliasing
+- The `Main 3D view anti-aliasing` option allows you to enable Multisample Anti-Aliasing
 on the 3D scene in Webots. This option can lead to reduced performance, but it improves 
 graphical fidelity significantly. It is disabled by default on systems that do not meet 
 our minimum requirements. Note that this option does not apply to any Camera rendering, 


### PR DESCRIPTION
This PR introduces new documentation corresponding to the option to enable MSAA in the Webots preferences, corresponding to https://github.com/omichel/webots/pull/4766
