### PR TITLE
Remove 'field' word from nodes declaration

### DIFF
--- a/automobile/ackermannvehicle.md
+++ b/automobile/ackermannvehicle.md
@@ -30,7 +30,7 @@ AckermannVehicle {
   SFFloat    suspensionRearSpringConstant   100000
   SFFloat    suspensionRearDampingConstant  4000
   SFFloat    wheelsDampingConstant          5
-  MFNode     extensionSlot                  NULL
+  MFNode     extensionSlot                  [ ]
   SFNode     boundingObject                 NULL
   SFNode     physics                        NULL
   SFNode     wheelFrontRight                AutomobileWheel { }

--- a/automobile/automobilewheel.md
+++ b/automobile/automobilewheel.md
@@ -30,7 +30,7 @@ AutomobileWheel {
   SFNode     tireAppearance     Appearance { material Material {} }
   SFNode     rimAppearance      Appearance { material Material {} }
   SFNode     physics            Physics {}
-  MFNode     logoSlot           []
+  MFNode     logoSlot           [ ]
 }
 ```
 

--- a/automobile/car.md
+++ b/automobile/car.md
@@ -81,18 +81,18 @@ from `extensionSlot`.
 
 ```
 AutomobileLights {
-  MFNode    front           NULL
+  MFNode    front           [ ]
   MFColor   frontColor      [ 0.8 0.8 0.8 ]
-  MFNode    rightIndicator  NULL
-  MFNode    leftIndicator   NULL
+  MFNode    rightIndicator  [ ]
+  MFNode    leftIndicator   [ ]
   MFColor   indicatorColor  [ 1 0.7 0.1 ]
-  MFNode    antifog         NULL
+  MFNode    antifog         [ ]
   MFColor   antifogColor    [ 0.8 0.8 0.8 ]
-  MFNode    braking         NULL
+  MFNode    braking         [ ]
   MFColor   brakingColor    [ 0.7 0.12 0.12 ]
-  MFNode    rear            NULL
+  MFNode    rear            [ ]
   MFColor   rearColor       [ 0.8 0.8 0.8 ]
-  MFNode    backwards       NULL
+  MFNode    backwards       [ ]
   MFColor   backwardsColor  [ 0.7 0.12 0.12 ]
 }
 ```

--- a/automobile/road-segments.md
+++ b/automobile/road-segments.md
@@ -39,7 +39,7 @@ Road {
   MFString   texture                   "textures/road.jpg"
   SFFloat    textureScale              2
   MFString   pavementTexture           "textures/pavement.jpg"
-  MFString   bottomTexture             []
+  MFString   bottomTexture             [ ]
   SFBool     locked                    TRUE
   SFBool     roadBoundingObject        FALSE
   SFBool     rightBorderBoundingObject FALSE

--- a/reference/accelerometer.md
+++ b/reference/accelerometer.md
@@ -4,7 +4,7 @@ Derived from [Device](device.md).
 
 ```
 Accelerometer {
-  MFVec3f    lookupTable    []    # interpolation
+  MFVec3f    lookupTable    [ ]   # interpolation
   SFBool     xAxis          TRUE  # compute x-axis
   SFBool     yAxis          TRUE  # compute y-axis
   SFBool     zAxis          TRUE  # compute z-axis

--- a/reference/background.md
+++ b/reference/background.md
@@ -2,12 +2,12 @@
 
 ```
 Background {
-  MFString backUrl   []
-  MFString bottomUrl []
-  MFString frontUrl  []
-  MFString leftUrl   []
-  MFString rightUrl  []
-  MFString topUrl    []
+  MFString backUrl   [ ]
+  MFString bottomUrl [ ]
+  MFString frontUrl  [ ]
+  MFString leftUrl   [ ]
+  MFString rightUrl  [ ]
+  MFString topUrl    [ ]
   MFColor  skyColor  [ 0 0 0 ] # [0,1]
 }
 ```

--- a/reference/balljointparameters.md
+++ b/reference/balljointparameters.md
@@ -2,9 +2,9 @@
 
 ```
 BallJointParameters {
-  field SFVec3f anchor 0 0 0      # point at which the bodies are connected (m)
-  field SFFloat springConstant  0 # uniform rotational spring constant (Nm)
-  field SFFloat dampingConstant 0 # uniform rotational damping constant (Nms)
+  SFVec3f anchor          0 0 0 # point at which the bodies are connected (m)
+  SFFloat springConstant  0     # uniform rotational spring constant (Nm)
+  SFFloat dampingConstant 0     # uniform rotational damping constant (Nms)
 }
 ```
 

--- a/reference/charger.md
+++ b/reference/charger.md
@@ -4,7 +4,7 @@ Derived from [Solid](solid.md).
 
 ```
 Charger {
-  MFFloat   battery        []
+  MFFloat   battery        [ ]
   SFFloat   radius         0.04    # (0,inf)
   SFColor   emissiveColor  0 1 0   # [0,1]
   SFBool    gradual        TRUE

--- a/reference/color.md
+++ b/reference/color.md
@@ -2,7 +2,7 @@
 
 ```
 Color {
-  MFColor   color   []   # [0,1]
+  MFColor   color   [ ]  # [0,1]
 }
 ```
 

--- a/reference/compass.md
+++ b/reference/compass.md
@@ -4,7 +4,7 @@ Derived from [Device](device.md).
 
 ```
 Compass {
-  MFVec3f    lookupTable    []    # interpolation
+  MFVec3f    lookupTable    [ ]   # interpolation
   SFBool     xAxis          TRUE  # compute x-axis
   SFBool     yAxis          TRUE  # compute y-axis
   SFBool     zAxis          TRUE  # compute z-axis

--- a/reference/coordinate.md
+++ b/reference/coordinate.md
@@ -2,7 +2,7 @@
 
 ```
 Coordinate {
-  MFVec3f   point   []   # (-inf,inf)
+  MFVec3f   point   [ ]  # (-inf,inf)
 }
 ```
 

--- a/reference/elevationgrid.md
+++ b/reference/elevationgrid.md
@@ -3,7 +3,7 @@
 ```
 ElevationGrid {
   SFNode    color            NULL
-  MFFloat   height           []     # (-inf,inf)
+  MFFloat   height           [ ]    # (-inf,inf)
   SFBool    colorPerVertex   TRUE
   SFInt32   xDimension       0      # [0,inf)
   SFFloat   xSpacing         1      # (0,inf)

--- a/reference/fluid.md
+++ b/reference/fluid.md
@@ -4,15 +4,15 @@ Derived from [Transform](transform.md).
 
 ```
 Fluid {
-  SFString  description     ""
-  field     SFString         name           "fluid"   # used in ImmersionProperties
-  field     SFString         model           ""       # generic name of the fluid (eg: "sea")
-  field     SFString         description     ""       # a short (1 line) of description of the fluid
-  field     SFFloat          density         1000     # (kg/m^3) fluid density
-  field     SFFloat          viscosity       0.001    # (kg/(ms)) fluid's dynamic viscosity
-  field     SFVec3f          streamVelocity  0 0 0    # (m/s) linear fluid velocity
-  SFNode    boundingObject   NULL
-  SFBool    locked           FALSE
+  SFString  description    ""
+  SFString  name           "fluid"  # used in ImmersionProperties
+  SFString  model          ""       # generic name of the fluid (eg: "sea")
+  SFString  description    ""       # a short (1 line) of description of the fluid
+  SFFloat   density        1000     # (kg/m^3) fluid density
+  SFFloat   viscosity      0.001    # (kg/(ms)) fluid's dynamic viscosity
+  SFVec3f   streamVelocity 0 0 0    # (m/s) linear fluid velocity
+  SFNode    boundingObject NULL
+  SFBool    locked         FALSE
 }
 ```
 

--- a/reference/group.md
+++ b/reference/group.md
@@ -2,7 +2,7 @@
 
 ```
 Group {
-  MFNode   children   []
+  MFNode   children   [ ]
 }
 ```
 

--- a/reference/gyro.md
+++ b/reference/gyro.md
@@ -4,7 +4,7 @@ Derived from [Device](device.md).
 
 ```
 Gyro {
-  MFVec3f    lookupTable    []    # interpolation
+  MFVec3f    lookupTable    [ ]   # interpolation
   SFBool     xAxis          TRUE  # compute x-axis
   SFBool     yAxis          TRUE  # compute y-axis
   SFBool     zAxis          TRUE  # compute z-axis

--- a/reference/hinge2joint.md
+++ b/reference/hinge2joint.md
@@ -4,9 +4,9 @@ Derived from [HingeJoint](hingejoint.md).
 
 ```
 Hinge2Joint {
-  SFNode jointParameters2 NULL     # JointParameters for second axis
-  MFNode device2          [ ]      # RotationalMotor, PositionSensor and Brake
-  hiddenField SFFloat position2  0 # initial position with respect to the second hinge (rad)
+  SFNode   jointParameters2 NULL     # JointParameters for second axis
+  MFNode   device2          []       # RotationalMotor, PositionSensor and Brake
+  SFFloat .position2        0        # initial position with respect to the second hinge (rad)
 }
 ```
 
@@ -49,4 +49,4 @@ empty, default values of the HingeJointParameters node apply.
 [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device attached
 to the second axis. If no motor is specified, this part of the joint is passive.
 
-- `position2`: see [joint's hidden position field](rotationalmotor.md).
+- `.position2`: see [joint's hidden position field](rotationalmotor.md).

--- a/reference/hinge2joint.md
+++ b/reference/hinge2joint.md
@@ -4,8 +4,8 @@ Derived from [HingeJoint](hingejoint.md).
 
 ```
 Hinge2Joint {
-  field SFNode jointParameters2 NULL # JointParameters for second axis
-  field MFNode device2 [ ] # RotationalMotor, PositionSensor and Brake
+  SFNode jointParameters2 NULL     # JointParameters for second axis
+  MFNode device2          [ ]      # RotationalMotor, PositionSensor and Brake
   hiddenField SFFloat position2  0 # initial position with respect to the second hinge (rad)
 }
 ```

--- a/reference/hinge2joint.md
+++ b/reference/hinge2joint.md
@@ -4,9 +4,9 @@ Derived from [HingeJoint](hingejoint.md).
 
 ```
 Hinge2Joint {
-  SFNode   jointParameters2 NULL     # JointParameters for second axis
-  MFNode   device2          [ ]      # RotationalMotor, PositionSensor and Brake
-  SFFloat .position2        0        # initial position with respect to the second hinge (rad)
+  SFNode  jointParameters2 NULL     # JointParameters for second axis
+  MFNode  device2          [ ]      # RotationalMotor, PositionSensor and Brake
+  SFFloat position2        0        # initial position with respect to the second hinge (rad)
 }
 ```
 
@@ -49,4 +49,4 @@ empty, default values of the HingeJointParameters node apply.
 [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device attached
 to the second axis. If no motor is specified, this part of the joint is passive.
 
-- `.position2`: see [joint's hidden position field](joint.md#joint-s-hidden-position-fields).
+- `position2`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joint-s-hidden-position-fields).

--- a/reference/hinge2joint.md
+++ b/reference/hinge2joint.md
@@ -49,4 +49,4 @@ empty, default values of the HingeJointParameters node apply.
 [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device attached
 to the second axis. If no motor is specified, this part of the joint is passive.
 
-- `.position2`: see [joint's hidden position field](rotationalmotor.md).
+- `.position2`: see [joint's hidden position field](joint.md#joint-s-hidden-position-fields).

--- a/reference/hinge2joint.md
+++ b/reference/hinge2joint.md
@@ -5,7 +5,7 @@ Derived from [HingeJoint](hingejoint.md).
 ```
 Hinge2Joint {
   SFNode   jointParameters2 NULL     # JointParameters for second axis
-  MFNode   device2          []       # RotationalMotor, PositionSensor and Brake
+  MFNode   device2          [ ]      # RotationalMotor, PositionSensor and Brake
   SFFloat .position2        0        # initial position with respect to the second hinge (rad)
 }
 ```

--- a/reference/hingejoint.md
+++ b/reference/hingejoint.md
@@ -30,5 +30,4 @@ with a [HingeJointParameters](hingejointparameters.md) only. If empty,
 [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device. If no
 motor is specified, the joint is passive joint.
 
-- `.position`: see [joint's hidden position
-field](joint.md#joint-s-hidden-position-fields).
+- `.position`: see [joint's hidden position field](joint.md#joint-s-hidden-position-fields).

--- a/reference/hingejoint.md
+++ b/reference/hingejoint.md
@@ -4,8 +4,8 @@ Derived from [Joint](joint.md).
 
 ```
 HingeJoint {
-  MFNode  device   []              # RotationalMotor, PositionSensor and Brake
-  hiddenField SFFloat position 0   # (rad) initial position
+  MFNode   device   []  # RotationalMotor, PositionSensor and Brake
+  SFFloat .position 0   # (rad) initial position
 }
 ```
 
@@ -30,5 +30,5 @@ with a [HingeJointParameters](hingejointparameters.md) only. If empty,
 [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device. If no
 motor is specified, the joint is passive joint.
 
-- `position`: see [joint's hidden position
+- `.position`: see [joint's hidden position
 field](joint.md#joint-s-hidden-position-fields).

--- a/reference/hingejoint.md
+++ b/reference/hingejoint.md
@@ -4,8 +4,8 @@ Derived from [Joint](joint.md).
 
 ```
 HingeJoint {
-  MFNode   device   [ ] # RotationalMotor, PositionSensor and Brake
-  SFFloat .position 0   # (rad) initial position
+  MFNode  device   [ ] # RotationalMotor, PositionSensor and Brake
+  SFFloat position 0   # (rad) initial position
 }
 ```
 
@@ -30,4 +30,4 @@ with a [HingeJointParameters](hingejointparameters.md) only. If empty,
 [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device. If no
 motor is specified, the joint is passive joint.
 
-- `.position`: see [joint's hidden position field](joint.md#joint-s-hidden-position-fields).
+- `position`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joint-s-hidden-position-fields).

--- a/reference/hingejoint.md
+++ b/reference/hingejoint.md
@@ -4,7 +4,7 @@ Derived from [Joint](joint.md).
 
 ```
 HingeJoint {
-  MFNode   device   []  # RotationalMotor, PositionSensor and Brake
+  MFNode   device   [ ] # RotationalMotor, PositionSensor and Brake
   SFFloat .position 0   # (rad) initial position
 }
 ```

--- a/reference/hingejoint.md
+++ b/reference/hingejoint.md
@@ -4,7 +4,7 @@ Derived from [Joint](joint.md).
 
 ```
 HingeJoint {
-  field       MFNode  device   [ ] # RotationalMotor, PositionSensor and Brake
+  MFNode  device   []              # RotationalMotor, PositionSensor and Brake
   hiddenField SFFloat position 0   # (rad) initial position
 }
 ```

--- a/reference/hingejointparameters.md
+++ b/reference/hingejointparameters.md
@@ -4,12 +4,12 @@ Derived from [JointParameters](jointparameters.md).
 
 ```
 HingeJointParameters {
-  field SFVec3f anchor                    0 0 0 # for the rotation axis (m)
+  SFVec3f anchor                    0 0 0 # for the rotation axis (m)
   # the following field have different default values than the parent class
-  field SFVec3f axis                      1 0 0 # rotation axis
-  field SFFloat suspensionSpringConstant  0     # linear spring constant along the suspension axis (Ns/m)
-  field SFFloat suspensionDampingConstant 0     # linear damping constant along the suspension axis (Ns/m)
-  field SFVec3f suspensionAxis            1 0 0 # direction of the suspension axis
+  SFVec3f axis                      1 0 0 # rotation axis
+  SFFloat suspensionSpringConstant  0     # linear spring constant along the suspension axis (Ns/m)
+  SFFloat suspensionDampingConstant 0     # linear damping constant along the suspension axis (Ns/m)
+  SFVec3f suspensionAxis            1 0 0 # direction of the suspension axis
 }
 ```
 

--- a/reference/imagetexture.md
+++ b/reference/imagetexture.md
@@ -2,7 +2,7 @@
 
 ```
 ImageTexture {
-  MFString   url       []
+  MFString   url       [ ]
   SFBool     repeatS   TRUE
   SFBool     repeatT   TRUE
   SFBool     filtering TRUE

--- a/reference/immersionproperties.md
+++ b/reference/immersionproperties.md
@@ -2,12 +2,12 @@
 
 ```
 ImmersionProperties {
-  field SFString   fluidName       ""
-  field SFString   referenceArea   "immersed area"
-  field SFVec3f    dragForceCoefficients  0 0 0 # dimensionless coefficient ranging in [0, infinity)
-  field SFVec3f    dragTorqueCoefficients  0 0 0 # dimensionless coefficients ranging in [0, infinity)
-  field SFFloat    viscousResistanceForceCoefficient  0 # (Ns/m) ranges in [0, infinity)
-  field SFFloat    viscousResistanceTorqueCoefficient  0 # (Nm/s ) ranges in [0, infinity)
+  SFString   fluidName                          ""
+  SFString   referenceArea                      "immersed area"
+  SFVec3f    dragForceCoefficients               0 0 0 # dimensionless coefficient ranging in [0, infinity)
+  SFVec3f    dragTorqueCoefficients              0 0 0 # dimensionless coefficients ranging in [0, infinity)
+  SFFloat    viscousResistanceForceCoefficient   0     # (Ns/m) ranges in [0, infinity)
+  SFFloat    viscousResistanceTorqueCoefficient  0     # (Nm/s ) ranges in [0, infinity)
 }
 ```
 

--- a/reference/indexedfaceset.md
+++ b/reference/indexedfaceset.md
@@ -7,8 +7,8 @@ IndexedFaceSet {
   SFBool    solid           TRUE  # ignored and regarded as TRUE
   SFBool    ccw             TRUE
   SFBool    convex          TRUE
-  MFInt32   coordIndex      []    # [-1,inf)
-  MFInt32   texCoordIndex   []    # [-1,inf)
+  MFInt32   coordIndex      [ ]   # [-1,inf)
+  MFInt32   texCoordIndex   [ ]   # [-1,inf)
   SFFloat   creaseAngle     0     # [0,inf)
 }
 ```

--- a/reference/indexedlineset.md
+++ b/reference/indexedlineset.md
@@ -3,7 +3,7 @@
 ```
 IndexedLineSet {
   SFNode    coord        NULL
-  MFInt32   coordIndex   []    # [-1,inf)
+  MFInt32   coordIndex   [ ]   # [-1,inf)
 }
 ```
 

--- a/reference/inertialunit.md
+++ b/reference/inertialunit.md
@@ -4,7 +4,7 @@ Derived from [Device](device.md).
 
 ```
 InertialUnit {
-  MFVec3f    lookupTable    []    # interpolation
+  MFVec3f    lookupTable    [ ]   # interpolation
   SFBool     xAxis          TRUE  # compute roll
   SFBool     zAxis          TRUE  # compute pitch
   SFBool     yAxis          TRUE  # compute yaw

--- a/reference/joint.md
+++ b/reference/joint.md
@@ -2,8 +2,8 @@
 
 ```
 Joint {
-  field SFNode jointParameters NULL # a joint parameters node
-  field SFNode endPoint        NULL # Solid or SolidReference
+  SFNode jointParameters NULL # a joint parameters node
+  SFNode endPoint        NULL # Solid or SolidReference
 }
 ```
 

--- a/reference/jointparameters.md
+++ b/reference/jointparameters.md
@@ -2,13 +2,13 @@
 
 ```
 JointParameters {
-  field SFFloat position        0 # current position (m or rad)
-  field SFVec3f axis        0 0 1 # displacement axis (m)
-  field SFFloat minStop         0 # low stop position (m or rad)
-  field SFFloat maxStop         0 # high stop position (m or rad)
-  field SFFloat springConstant  0 # spring constant (N/m or Nm)
-  field SFFloat dampingConstant 0 # damping constant (Ns/m or Nms)
-  field SFFloat staticFriction  0 # friction constant (Ns/m or Nms)
+  SFFloat position        0 # current position (m or rad)
+  SFVec3f axis        0 0 1 # displacement axis (m)
+  SFFloat minStop         0 # low stop position (m or rad)
+  SFFloat maxStop         0 # high stop position (m or rad)
+  SFFloat springConstant  0 # spring constant (N/m or Nm)
+  SFFloat dampingConstant 0 # damping constant (Ns/m or Nms)
+  SFFloat staticFriction  0 # friction constant (Ns/m or Nms)
 }
 ```
 

--- a/reference/linearmotor.md
+++ b/reference/linearmotor.md
@@ -4,9 +4,9 @@ Derived from [Motor](motor.md).
 
 ```
 LinearMotor {
-  field SFString name     "linear motor"            # used by wb_robot_get_device()
-  field SFFloat  maxForce 10                        # max force (N) : [0, inf)
-  field SFString sound    "sounds/linear_motor.wav" # see Motor description
+  SFString name     "linear motor"            # used by wb_robot_get_device()
+  SFFloat  maxForce 10                        # max force (N) : [0, inf)
+  SFString sound    "sounds/linear_motor.wav" # see Motor description
 }
 ```
 

--- a/reference/physics.md
+++ b/reference/physics.md
@@ -5,7 +5,7 @@ Physics {
   SFFloat     density             1000      # (kg/m^3) -1 or > 0
   SFFloat     mass                -1        # (kg) -1 or > 0
   SFVec3f     centerOfMass        0 0 0     # (-inf,inf)
-  MFVec3f     inertiaMatrix       []        # empty or 2 values
+  MFVec3f     inertiaMatrix       [ ]       # empty or 2 values
   SFNode      damping             NULL      # optional damping node
 }
 ```

--- a/reference/propeller.md
+++ b/reference/propeller.md
@@ -2,13 +2,13 @@
 
 ```
 Propeller {
-  field SFVec3f shaftAxis       1 0 0 # (m)
-  field SFVec3f centerOfThrust  0 0 0 # (m)
-  field SFVec2f thrustConstants 1 0   # Ns^2/rad : (-inf, inf), Ns^2/(m*rad) : (-inf, inf)
-  field SFVec2f torqueConstants 1 0   # Nms^2/rad : (-inf, inf), Ns^2/rad : (-inf, inf)
-  field SFNode device           NULL  # RotationalMotor
-  field SFNode fastHelix        NULL  # Solid node containing a graphical representation for rotation speed > 24 π rad/s (720 rpm)
-  field SFNode slowHelix        NULL  # Solid node containing a graphical representation for rotation speed <= 24 π rad/s
+  SFVec3f shaftAxis       1 0 0 # (m)
+  SFVec3f centerOfThrust  0 0 0 # (m)
+  SFVec2f thrustConstants 1 0   # Ns^2/rad : (-inf, inf), Ns^2/(m*rad) : (-inf, inf)
+  SFVec2f torqueConstants 1 0   # Nms^2/rad : (-inf, inf), Ns^2/rad : (-inf, inf)
+  SFNode device           NULL  # RotationalMotor
+  SFNode fastHelix        NULL  # Solid node containing a graphical representation for rotation speed > 24 π rad/s (720 rpm)
+  SFNode slowHelix        NULL  # Solid node containing a graphical representation for rotation speed <= 24 π rad/s
 }
 ```
 

--- a/reference/proto-example.md
+++ b/reference/proto-example.md
@@ -24,7 +24,8 @@ PROTO TwoColorChair [
   field SFColor    legColor          1 1 0
   field SFColor    seatColor         1 0.65 0
   field SFNode     seatGeometry      NULL
-  field MFNode     seatExtensionSlot []       ]
+  field MFNode     seatExtensionSlot []
+]
 {
   Solid {
     translation IS translation

--- a/reference/robot.md
+++ b/reference/robot.md
@@ -8,7 +8,7 @@ Robot {
   SFString   controllerArgs    ""
   SFString   data              ""
   SFBool     synchronization   TRUE
-  MFFloat    battery           []
+  MFFloat    battery           [ ]
   SFFloat    cpuConsumption    10  # [0,inf)
   SFBool     selfCollision     FALSE
   SFBool     showWindow        FALSE

--- a/reference/rotationalmotor.md
+++ b/reference/rotationalmotor.md
@@ -4,9 +4,9 @@ Derived from [Motor](motor.md).
 
 ```
 RotationalMotor {
-  field SFString name      "rotational motor"            # for wb_robot_get_device()
-  field SFFloat  maxTorque 10                            # max torque (Nm) : [0, inf)
-  field SFString sound     "sounds/rotational_motor.wav" # see Motor description
+  SFString name      "rotational motor"            # for wb_robot_get_device()
+  SFFloat  maxTorque 10                            # max torque (Nm) : [0, inf)
+  SFString sound     "sounds/rotational_motor.wav" # see Motor description
 }
 ```
 

--- a/reference/sliderjoint.md
+++ b/reference/sliderjoint.md
@@ -4,8 +4,8 @@ Derived from [Joint](joint.md).
 
 ```
 SliderJoint {
-  MFNode  device   []               # linear motor or linear position sensor
-  hiddenField SFFloat position 0    # initial position (m)
+  MFNode   device   []    # linear motor or linear position sensor
+  SFFloat .position 0     # initial position (m)
 }
 ```
 
@@ -29,5 +29,5 @@ with a [JointParameters](jointparameters.md) only. If empty,
 linear [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device. If
 no motor is specified, the joint is passive joint.
 
-- `position`: see [joint's hidden position
+- `.position`: see [joint's hidden position
 field](joint.md#joint-s-hidden-position-fields).

--- a/reference/sliderjoint.md
+++ b/reference/sliderjoint.md
@@ -4,7 +4,7 @@ Derived from [Joint](joint.md).
 
 ```
 SliderJoint {
-  MFNode   device   []    # linear motor or linear position sensor
+  MFNode   device   [ ]   # linear motor or linear position sensor
   SFFloat .position 0     # initial position (m)
 }
 ```

--- a/reference/sliderjoint.md
+++ b/reference/sliderjoint.md
@@ -4,8 +4,8 @@ Derived from [Joint](joint.md).
 
 ```
 SliderJoint {
-  field       MFNode  device   [ ]        # linear motor or linear position sensor
-  hiddenField SFFloat position 0          # initial position (m)
+  MFNode  device   []               # linear motor or linear position sensor
+  hiddenField SFFloat position 0    # initial position (m)
 }
 ```
 

--- a/reference/sliderjoint.md
+++ b/reference/sliderjoint.md
@@ -29,5 +29,4 @@ with a [JointParameters](jointparameters.md) only. If empty,
 linear [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device. If
 no motor is specified, the joint is passive joint.
 
-- `.position`: see [joint's hidden position
-field](joint.md#joint-s-hidden-position-fields).
+- `.position`: see [joint's hidden position field](joint.md#joint-s-hidden-position-fields).

--- a/reference/sliderjoint.md
+++ b/reference/sliderjoint.md
@@ -4,8 +4,8 @@ Derived from [Joint](joint.md).
 
 ```
 SliderJoint {
-  MFNode   device   [ ]   # linear motor or linear position sensor
-  SFFloat .position 0     # initial position (m)
+  MFNode  device   [ ]   # linear motor or linear position sensor
+  SFFloat position 0     # initial position (m)
 }
 ```
 
@@ -29,4 +29,4 @@ with a [JointParameters](jointparameters.md) only. If empty,
 linear [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device. If
 no motor is specified, the joint is passive joint.
 
-- `.position`: see [joint's hidden position field](joint.md#joint-s-hidden-position-fields).
+- `position`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joint-s-hidden-position-fields).

--- a/reference/slot.md
+++ b/reference/slot.md
@@ -2,8 +2,8 @@
 
 ```
 Slot {
-  field     SFString type      ""
-  vrmlField SFNode   endPoint  NULL
+  SFString type      ""
+  SFNode   endPoint  NULL
 }
 ```
 

--- a/reference/solid.md
+++ b/reference/solid.md
@@ -15,8 +15,8 @@ Solid {
   SFFloat    radarCrossSection   0.0
   SFFloat    translationStep     0.01        # m
   SFFloat    rotationStep        0.261799387 # pi/12 rad
-  SFVec3f   .linearVelocity      0 0 0       # initial linear velocity
-  SFVec3f   .angularVelocity     0 0 0       # initial angular velocity
+  SFVec3f    linearVelocity      0 0 0       # initial linear velocity
+  SFVec3f    angularVelocity     0 0 0       # initial angular velocity
 }
 ```
 
@@ -97,7 +97,7 @@ that will be used by the translate and rotate handles appearing in the 3D window
 when selecting a top solid. Continuous increment is obtained by setting the step
 value to -1.
 
-- `.linearVelocity` and `.angularVelocity`: these fields, which aren't visible from
+- `linearVelocity` and `angularVelocity`: these fields, which aren't visible from
 the Scene Tree, are used by Webots when saving a world file to store the initial
 linear and angular velocities of a [Solid](#solid) with a non-NULL
 [Physics](physics.md) node. If the [Solid](#solid) node is merged into a solid

--- a/reference/solid.md
+++ b/reference/solid.md
@@ -15,9 +15,8 @@ Solid {
   SFFloat    radarCrossSection   0.0
   SFFloat    translationStep     0.01        # m
   SFFloat    rotationStep        0.261799387 # pi/12 rad
-  # hidden fields
-  hiddenField SFVec3f linearVelocity 0 0 0 # initial linear velocity
-  hiddenField SFVec3f angularVelocity 0 0 0 # initial angular velocity
+  SFVec3f   .linearVelocity      0 0 0       # initial linear velocity
+  SFVec3f   .angularVelocity     0 0 0       # initial angular velocity
 }
 ```
 
@@ -98,7 +97,7 @@ that will be used by the translate and rotate handles appearing in the 3D window
 when selecting a top solid. Continuous increment is obtained by setting the step
 value to -1.
 
-- `linearVelocity` and `angularVelocity`: these fields, which aren't visible from
+- `.linearVelocity` and `.angularVelocity`: these fields, which aren't visible from
 the Scene Tree, are used by Webots when saving a world file to store the initial
 linear and angular velocities of a [Solid](#solid) with a non-NULL
 [Physics](physics.md) node. If the [Solid](#solid) node is merged into a solid

--- a/reference/solid.md
+++ b/reference/solid.md
@@ -8,7 +8,7 @@ Solid {
   SFString   model               ""
   SFString   description         ""
   SFString   contactMaterial     "default"
-  MFNode     immersionProperties []
+  MFNode     immersionProperties [ ]
   SFNode     boundingObject      NULL
   SFNode     physics             NULL
   SFBool     locked              FALSE

--- a/reference/solidreference.md
+++ b/reference/solidreference.md
@@ -2,7 +2,7 @@
 
 ```
 SolidReference {
-  field  SFString  solidName  "" # name of an existing solid or <static environment>
+  SFString  solidName  "" # name of an existing solid or <static environment>
 }
 ```
 

--- a/reference/texturecoordinate.md
+++ b/reference/texturecoordinate.md
@@ -2,7 +2,7 @@
 
 ```
 TextureCoordinate {
-  MFVec2f   point   []   # (-inf,inf)
+  MFVec2f   point   [ ]   # (-inf,inf)
 }
 ```
 

--- a/reference/track.md
+++ b/reference/track.md
@@ -4,7 +4,7 @@ Derived from [Solid](solid.md).
 
 ```
 Track {
-  MFNode     device            []
+  MFNode     device            [ ]
   SFVec3f    textureAnimation  0 0
   SFNode     animatedGeometry  NULL
   SFInt32    geometriesCount   10

--- a/reference/worldinfo.md
+++ b/reference/worldinfo.md
@@ -3,7 +3,7 @@
 ```
 WorldInfo {
   SFString   title                          ""
-  MFString   info                           []
+  MFString   info                           [ ]
   SFVec3f    gravity                        0 -9.81 0
   SFFloat    CFM                            0.00001  # [0,inf)
   SFFloat    ERP                            0.2      # [0,1]
@@ -20,7 +20,7 @@ WorldInfo {
   SFString   gpsCoordinateSystem            "local"  # should either be 'local' or 'WGS84'
   SFVec3f    gpsReference                   0 0 0    # defines the offset for each coordinate [m]
   SFFloat    lineScale                      0.1      # control the length of every arbitrary-sized lines
-  MFNode     contactProperties              []       # see ContactProperties node
+  MFNode     contactProperties              [ ]      # see ContactProperties node
 }
 ```
 

--- a/reference/zoom.md
+++ b/reference/zoom.md
@@ -2,8 +2,8 @@
 
 ```
 Zoom {
-   SFFloat     maxFieldOfView 1.5 # (rad)
-   SFFloat     minFieldOfView 0.5 # (rad)
+  SFFloat     maxFieldOfView 1.5 # (rad)
+  SFFloat     minFieldOfView 0.5 # (rad)
 }
 ```
 


### PR DESCRIPTION
Currently the nodes declaration is not consistent: some nodes use the 'field' world but most of them don't use it.

I removed it to make the declaration consistent.
It remains to decide what to do with 'hiddenField' words.