### PR TITLE
Fix description of anchor coordinate system

### DIFF
--- a/reference/balljointparameters.md
+++ b/reference/balljointparameters.md
@@ -19,14 +19,13 @@ attached. It can be used in the jointParameters field of
 ### Field Summary
 
 - `anchor`: This field specifies the anchor position expressed in relative
-coordinates with respect to the center of the closest upper [Solid](solid.md)'s
-frame.
+coordinates with respect to the center of the closest upper [Transform](transform.md) node's frame.
 
 - `springConstant` and `dampingConstant`: These fields specify the uniform amount
 of rotational spring and damping effect around each of the frame axis of the
-[BallJoint](balljoint.md)'s closest upper [Solid](solid.md) (see
-[Joint](joint.md)'s ["Springs and
-Dampers"](jointparameters.md#springs-and-dampers) section for more information
-on these constants). This is can be useful to simulate a retraction force that
+[BallJoint](balljoint.md)'s closest upper [Transform](transform.md) (see
+[JointParameters](jointparameters.md)'s ["Springs and Dampers"](jointparameters.md#springs-and-dampers) section
+for more information on these constants).
+This is can be useful to simulate a retraction force that
 pulls the [BallJoint](balljoint.md) solid `endPoint` back towards its initial
 orientation.

--- a/reference/hingejointparameters.md
+++ b/reference/hingejointparameters.md
@@ -38,4 +38,4 @@ constant along the suspension axis.
 The `suspensionSpringConstant` and `suspensionDampingConstant` fields can be
 used to add a linear spring and/or damping behavior *along* the axis defined in
 `suspensionAxis`. These fields are described in more detail in
-[JointParameters Springs and Dampers](jointparameters.md#springs-and-dampers) section.
+[JointParameters](jointparameters.md)'s ["Springs and Dampers"](jointparameters.md#springs-and-dampers) section.

--- a/reference/hingejointparameters.md
+++ b/reference/hingejointparameters.md
@@ -25,7 +25,7 @@ stop angles, spring and damping constants etc.) related to this rotation axis.
 the hinge axis passes. Together with the `axis` field inherited from the
 [JointParameters](jointparameters.md) node, the `anchor` field determines the
 hinge rotation axis in a unique way. It is expressed in relative coordinates
-with respect to the closest upper [Solid](solid.md)'s frame.
+with respect to the closest upper [Transform](transform.md) node's frame.
 
 - `suspensionSpringConstant`: This field specifies the suspension spring constant
 along the suspension axis.
@@ -38,4 +38,4 @@ constant along the suspension axis.
 The `suspensionSpringConstant` and `suspensionDampingConstant` fields can be
 used to add a linear spring and/or damping behavior *along* the axis defined in
 `suspensionAxis`. These fields are described in more detail in
-[JointParameters](jointparameters.md)'s Springs and Dampers" section.
+[JointParameters Springs and Dampers](jointparameters.md#springs-and-dampers) section.

--- a/reference/joint.md
+++ b/reference/joint.md
@@ -38,8 +38,8 @@ a [BallJoint](balljoint.md).
     refers to the second rotation axis.
 
     3D-vector parameters (e.g `axis, anchor`) are always expressed in relative
-    coordinates with respect to the closest upper [Solid](solid.md)'s frame using
-    the meter as unit. If the  `jointParameters` field is not specified, parameters
+    coordinates with respect to the closest upper [Transform](transform.md)'s frame using
+    the meter as unit. If the `jointParameters` field is not specified, parameters
     are set with the default values defined in the corresponding parameter node.
 
 - `endPoint`: this field specifies which [Solid](solid.md) will be subjected to


### PR DESCRIPTION
Documentation still refer to Solid joint ancestor to describe the coordinate system of the anchor field, but it should refer to Transform node.