### PR TITLE
Rename `Mac OS X` to `macOS`

### DIFF
--- a/automobile/sumo-interface.md
+++ b/automobile/sumo-interface.md
@@ -66,8 +66,8 @@ field `controllerArgs` in order to customize the behavior of the interface:
 %end
 
 
-> **Note** [Mac OS X]:
-On Mac OS X, SUMO relies on X11. You need therefore to install [XQuartz](https://www.xquartz.org) (version 2.7.8 or later) for the interface to work.
+> **Note** [macOS]:
+On macOS, SUMO relies on X11. You need therefore to install [XQuartz](https://www.xquartz.org) (version 2.7.8 or later) for the interface to work.
 
 
 ## Plugin mechanism

--- a/guide/classroom-license-setup.md
+++ b/guide/classroom-license-setup.md
@@ -100,7 +100,7 @@ be saved and the students won't need to enter it again. You may also automate
 this process by copying an already configured Webots preferences to all the user
 accounts used by the students. On Windows, the Webots preferences are stored in
 the registry under the "HKEY\_CURRENT\_USER/SOFTWARE/Cyberbotics" key (so you
-need to use a tool that copies registry keys across user accounts). On Mac OS X,
+need to use a tool that copies registry keys across user accounts). On macOS,
 the Webots preferences are stored in a file under the user home directory at
 "~/Library/Preferences/com.cyberbotics.Webots-{{ webots.version.major }}.{{
 webots.version.minor }}.plist". On Linux, the Webots

--- a/guide/compiling-controllers-in-a-terminal.md
+++ b/guide/compiling-controllers-in-a-terminal.md
@@ -7,7 +7,7 @@ variable is used to locate Webots header files and libraries in the Makefiles.
 Setting an environment variable depends on the platform (and shell), here are
 some examples:
 
-### Mac OS X and Linux
+### macOS and Linux
 
 These examples assume that Webots is installed in the default directory. On
 Linux, type this:
@@ -16,7 +16,7 @@ Linux, type this:
 $ export WEBOTS_HOME=/usr/local/webots
 ```
 
-or add this line to your "~/.bash\_profile" file. On Mac OS X, type this:
+or add this line to your "~/.bash\_profile" file. On macOS, type this:
 
 ```sh
 $ export WEBOTS_HOME=/Applications/Webots

--- a/guide/controller-programming.md
+++ b/guide/controller-programming.md
@@ -554,7 +554,7 @@ replaced by the actual value already existing in the environment. The Webots
     controller is ran on the Windows platform. If you want to declare paths in this
     section, the value should be written between double-quotes symbols ".
 
-- `[environment variables for Mac OS X]`
+- `[environment variables for macOS]`
 
     Variables defined here will only be added on macOS and ignored on other
     platforms.
@@ -586,7 +586,7 @@ ROS_MASTER_URI = http://localhost:11311
 [environment variables for Windows]
 NAOQI_LIBRARY_FOLDER = "bin;C:\Users\My Documents\Naoqi\bin"
 
-[environment variables for Mac OS X]
+[environment variables for macOS]
 NAOQI_LIBRARY_FOLDER = lib
 
 [environment variables for Linux]

--- a/guide/controller-programming.md
+++ b/guide/controller-programming.md
@@ -556,7 +556,7 @@ replaced by the actual value already existing in the environment. The Webots
 
 - `[environment variables for Mac OS X]`
 
-    Variables defined here will only be added on Mac OS X and ignored on other
+    Variables defined here will only be added on macOS and ignored on other
     platforms.
 
 - `[environment variables for Linux]`
@@ -603,7 +603,7 @@ you to access specific options that will be passed immediately to the language
 interpreter. For example:
 
 ```ini
-; runtime.ini for a Python controller on Mac OS X
+; runtime.ini for a Python controller on macOS
 
 [python]
 COMMAND = /opt/local/bin/python2.7

--- a/guide/debugging-c-cpp-controllers.md
+++ b/guide/debugging-c-cpp-controllers.md
@@ -32,7 +32,7 @@ $ ps -e
 ...
 ```
 
-On Mac OS X, use rather `ps -x` and on Windows use the *Task Manager* for this.
+On macOS, use rather `ps -x` and on Windows use the *Task Manager* for this.
 If one of your robot controllers is missing in the list (or appearing as
 *<defunct>*) this confirms that it has crashed and therefore blocked the
 simulation. In this example the "soccer\_supervisor" has crashed. Note that the
@@ -65,7 +65,7 @@ Note that, the *-g* flag should now appear in the compilation line. Once you
 have recompiled the controller, hit the `Pause` and `Revert` buttons. This
 pauses the simulation and reloads the freshly compiled versions of the
 controller. Now find the process ID (PID) of the "soccer\_supervisor" process,
-using `ps -e` (Linux) or `ps -x` (Mac OS X), or using the *Task Manager*
+using `ps -e` (Linux) or `ps -x` (macOS), or using the *Task Manager*
 (Windows). The PID is in the left-most column of output of `ps` as shown above.
 Then open a terminal and start the debugger by typing:
 

--- a/guide/index.md
+++ b/guide/index.md
@@ -39,7 +39,7 @@ K-Team S.A.
 
 *Linux*<sup>TM</sup> is a registered trademark of Linus Torvalds.
 
-*Mac OS X*<sup>TM</sup> is a registered trademark of Apple Inc.
+*macOS*<sup>TM</sup> is a registered trademark of Apple Inc.
 
 *Mindstorms*<sup>TM</sup> and *LEGO*<sup>TM</sup> are registered trademarks of
 the LEGO group.

--- a/guide/installation-procedure.md
+++ b/guide/installation-procedure.md
@@ -163,7 +163,7 @@ webots.version.bugfix }}\_setup.exe /SILENT" or "webots-{{ webots.version.major
 If you observe 3D rendering anomalies or if Webots crashes, it is strongly
 recommend to upgrade your graphics driver.
 
-### Installation on Mac OS X
+### Installation on macOS
 
 1. Download the "webots-{{ webots.version.major }}.{{ webots.version.minor }}.{{
 webots.version.bugfix }}.dmg" installation file from our [website](http://www.cyberbotics.com/macosx).
@@ -179,11 +179,11 @@ kern.sysv.shmmni=128
 kern.sysv.shmseg=32
 kern.sysv.shmall=4096
 ```
-These settings increase the amount of shared memory to four times the usual default. The current values are provided by the following command line: `sysctl -A | grep sysv.shm`. Please refer to the Mac OS X documentation to understand the exact meaning of each value. You will have to reboot your computer so that these changes are taken into account.
+These settings increase the amount of shared memory to four times the usual default. The current values are provided by the following command line: `sysctl -A | grep sysv.shm`. Please refer to the macOS documentation to understand the exact meaning of each value. You will have to reboot your computer so that these changes are taken into account.
 
-### Mac OS X security
+### macOS security
 
-During the first Webots launch, Mac OS X may complain about opening Webots because it is from an unidentified developer
+During the first Webots launch, macOS may complain about opening Webots because it is from an unidentified developer
 (see [this figure](#unidentified-developer-dialog)).
 
 %figure "Unidentified developer dialog"
@@ -193,7 +193,7 @@ During the first Webots launch, Mac OS X may complain about opening Webots becau
 %end
 
 In this case, `Ctrl + click` (or right-click) on the Webots icon, and select the `Open` menu item.
-Mac OS X should propose to open the application anyway
+macOS should propose to open the application anyway
 (see [this figure](#unidentified-developer-dialog)).
 
 %figure "Open Webots anyway"
@@ -202,6 +202,6 @@ Mac OS X should propose to open the application anyway
 
 %end
 
-In earlier versions of Mac OS X, this last operation may not work.
-In this case, refer to your Mac OS X security settings to open Webots anyway
+In earlier versions of macOS, this last operation may not work.
+In this case, refer to your macOS security settings to open Webots anyway
 (`System Preferences / Security & Privacy / General / Allow apps downloaded from:`).

--- a/guide/known-bugs.md
+++ b/guide/known-bugs.md
@@ -5,5 +5,5 @@ resolved on the short term but possible workarounds are explained.
 
 ## Sections
 - [General bugs](general-bugs.md)
-- [Mac OS X](mac-os-x.md)
+- [macOS](mac-os.md)
 - [Linux](linux.md)

--- a/guide/mac-os.md
+++ b/guide/mac-os.md
@@ -1,4 +1,4 @@
-## Mac OS X
+## macOS
 
 ### MATLAB and robot plugins
 

--- a/guide/menu.md
+++ b/guide/menu.md
@@ -77,5 +77,5 @@
     - [Speed/Performance](speed-performance.md)
 - [Known Bugs](known-bugs.md)
     - [General bugs](general-bugs.md)
-    - [Mac OS X](mac-os-x.md)
+    - [macOS](mac-os.md)
     - [Linux](linux.md)

--- a/guide/starting-webots.md
+++ b/guide/starting-webots.md
@@ -7,7 +7,7 @@ a list of possible starting points.
 
 Open a terminal and type `webots` to launch Webots.
 
-### Mac OS X
+### macOS
 
 Open the directory in which you installed the Webots package and double-click on
 the Webots icon.

--- a/guide/system-requirements.md
+++ b/guide/system-requirements.md
@@ -27,7 +27,7 @@ longer provided. Webots doesn't run on Ubuntu versions earlier than 12.04.
 - Windows: Webots runs on Windows 10 64-bit, Windows 8.1 64-bit, Windows 8 64-bit
 and Windows 7 64-bit. It is not supported on 32-bit versions of Windows and on
 older versions including Windows Vista and Windows XP.
-- Macintosh: Webots runs on Mac OS X 10.12 "Sierra" and 10.11 "El Capitan".
-Webots may work but is not officially supported on earlier versions of Mac OS X.
+- Macintosh: Webots runs on macOS 10.12 "Sierra" and 10.11 "El Capitan".
+Webots may work but is not officially supported on earlier versions of macOS.
 
 Other versions of Webots for other UNIX systems may be available upon request.

--- a/guide/the-3d-window.md
+++ b/guide/the-3d-window.md
@@ -1,4 +1,4 @@
-## The 3D Window
+macOS## The 3D Window
 
 ### Selecting an object
 
@@ -95,7 +95,7 @@ length of this vector.
 
 To apply a torque to an object, place the mouse pointer on it, hold down the Alt
 key and right mouse button together while dragging the mouse. Linux users should
-also hold down the Control key (Ctrl) together with the Alt key. Also, Mac OS X
+also hold down the Control key (Ctrl) together with the Alt key. Also, macOS
 users with a one-button mouse should hold down the Control key (Ctrl) to emulate
 the right mouse button. This way your are drawing a 3D-vector with origin the
 center of mass and whose end is located on the plane parallel to the view which

--- a/guide/the-3d-window.md
+++ b/guide/the-3d-window.md
@@ -1,4 +1,4 @@
-macOS## The 3D Window
+## The 3D Window
 
 ### Selecting an object
 

--- a/guide/the-user-interface.md
+++ b/guide/the-user-interface.md
@@ -100,7 +100,7 @@ you to take a screenshot of the current view in Webots. It opens a file dialog
 to save the current view as a PNG or JPG image.
 
 ![](images/movie-button.png =26x26) The `Make Movie...` item allows you to
-create MPEG movies (Linux and Mac OS X) or AVI movies (Windows). Once the movie
+create MPEG movies (Linux and macOS) or AVI movies (Windows). Once the movie
 recording is started, this item is changed in `Stop Movie...`. During the
 recording, it is possible to the change the running mode and pause the
 simulation. However, frames are only captured during Webots steps and not when

--- a/guide/using-c.md
+++ b/guide/using-c.md
@@ -18,15 +18,15 @@ compiler, so there is usually no need to install a separate compiler. The MinGW
 compiler is a port of the GNU Compiler Collection (gcc) on the Windows platform.
 The advantage of using the MinGW compiler will be the better portability of your
 controller code. If you develop your code with MinGW it will be straightforward
-to recompile it on the other Webots supported platforms: Mac OS X and Linux.
+to recompile it on the other Webots supported platforms: macOS and Linux.
 However, if you prefer using the Visual C++ compiler you will find instructions
 [here](using-visual-cpp-with-webots.md).
 
-#### Mac OS X Instructions
+#### macOS Instructions
 
 In order to compile C/C++ controllers on the Mac, you will need to install Apple
 Xcode. Xcode is a suite of tools, developed by Apple, for developing software
-for Mac OS X. Xcode is free and can be downloaded from the Apple App Store.
+for macOS. Xcode is free and can be downloaded from the Apple App Store.
 Webots will need principally the `gcc` (GNU C Compiler) and `make` commands of
 Xcode. To install these commands, start Xcode and go to Xcode menu, Preferences,
 Downloads, Components and click `Install` for "Command Line Tools".

--- a/guide/using-java.md
+++ b/guide/using-java.md
@@ -83,7 +83,7 @@ website](http://openjdk.java.net/install/index.html).
 
 If a Java controller fails to execute or compile, check that the `java`,
 respectively the `javac` commands are reachable. You can verify this easily by
-opening a Terminal (Linux and Mac OS X) or a Command Prompt (Windows) and typing
+opening a Terminal (Linux and macOS) or a Command Prompt (Windows) and typing
 `java` or `javac`. If these commands are not reachable from the Terminal (or
 Command Prompt) they will not be reachable by Webots. In this case, check that
 the JDK is installed and that your *PATH* variable is defined correctly as
@@ -99,9 +99,9 @@ image found.
 ```
 
 this is due to a 32-bit/64-bit incompatibility between Java Virtual Machine
-(JVM) and Webots. On Mac OS X this problem should disappear after you upgrade to
+(JVM) and Webots. On macOS this problem should disappear after you upgrade to
 a recent version of Webots (6.3.0 or newer). On Windows, Webots is only
-compatible with 64-bit versions of Java. On Linux (and Mac OS X) you should be
+compatible with 64-bit versions of Java. On Linux (and macOS) you should be
 able to solve this problem by replacing the default "java" command string by
 "java -d32" or "java -d64" in the dialog `Tools / Preferences / General / Java
 command`.
@@ -121,7 +121,7 @@ windows, the CLASSPATH looks like this,
 $ set CLASSPATH=C:\Program Files\java\jdk\bin;relative\mylib.jar
 ```
 
-while under Linux and Mac OS X, it looks like this:
+while under Linux and macOS, it looks like this:
 
 ```sh
 $ export CLASSPATH=/usr/lib/jvm/java/bin:relative/mylib.jar

--- a/guide/using-matlab.md
+++ b/guide/using-matlab.md
@@ -47,7 +47,7 @@ actual MATLAB installation directory and version):
 $ sudo ln -s /usr/local/MATLAB/R2016a/bin/matlab /usr/local/bin/matlab
 ```
 
-Similarly, on Mac OS X, if Webots is unable to find the "matlab" startup script
+Similarly, on macOS, if Webots is unable to find the "matlab" startup script
 then you should add a symlink in "/usr/bin":
 
 ```sh
@@ -75,7 +75,7 @@ any problem, or possible improvement about these files.
 
 ### Display information to Webots console
 
-On Linux and Mac OS X, the MATLAB output is redirected as is to the Webots
+On Linux and macOS, the MATLAB output is redirected as is to the Webots
 console. This means you can use all the MATLAB display features (`disp()`,
 `display()`, omitting the semicolon character at the end of a statement, etc.).
 
@@ -102,7 +102,7 @@ documentation this will be the case on 64-bit systems, and hence we advice
 64-bit Webots users (on Linux) to make sure that these packages are installed on
 their systems.
 
-On some Mac OS X systems the MATLAB interface will work only if you install the
+On some macOS systems the MATLAB interface will work only if you install the
 Xcode development environment, because `gcc` is required. An error message like
 this one, is a symptom of the above described problem:
 

--- a/guide/using-python.md
+++ b/guide/using-python.md
@@ -20,9 +20,9 @@ The Python API of Webots is built with Python 2.7. Python 2.7 or earlier
 versions are therefore recommended although more recent versions can work
 without guarantee. Python 3 is not supported.
 
-#### Mac OS X and Linux Instructions
+#### macOS and Linux Instructions
 
-Most of the Linux distributions have Python 2.7 already installed. Mac OS X also
+Most of the Linux distributions have Python 2.7 already installed. macOS also
 has Python installed by default. To check the current version of Python
 installed on your system, you can type in a terminal:
 

--- a/guide/using-ros.md
+++ b/guide/using-ros.md
@@ -14,7 +14,7 @@ message-passing between processes, and package management. It is based on a
 graph architecture where processing takes place in nodes that may receive, post
 and multiplex sensor, control, state, planning, actuator and other messages. The
 library is geared towards a Unix-like system and is supported under Linux,
-experimental on Mac OS X and has partial functionality under Windows.
+experimental on macOS and has partial functionality under Windows.
 
 ROS has two basic "sides": The operating system side, ros, as described above
 and ros-pkg, a suite of user contributed packages (organized into sets called
@@ -79,8 +79,8 @@ connect to each of the computer in ssh in both ways. As ROS uses the hostname to
 find other computers on the network, you must add other computers' hostname and
 the associated IP address to the known hosts of each computer. You can find this
 list in a file named *hosts*. On Linux distribution, you can find it directly at
-/etc/hosts; on Mac OS X, it is located at /private/etc/hosts; on Windows, it is
-located at C:\Windows\System32\drivers\etc\hosts. On Windows and Mac OS X, this
+/etc/hosts; on macOS, it is located at /private/etc/hosts; on Windows, it is
+located at C:\Windows\System32\drivers\etc\hosts. On Windows and macOS, this
 a hidden path and you will need to search directly for this path. The hosts file
 is usually protected and you will need administrator or root privileges to edit
 it.

--- a/guide/using-the-e-puck-robot.md
+++ b/guide/using-the-e-puck-robot.md
@@ -271,7 +271,7 @@ file.
 #### Bluetooth setup
 
 The e-puck has a Bluetooth interface allowing it to communicate with Webots.
-This feature is available under Windows, Linux and Mac OS X. The Bluetooth
+This feature is available under Windows, Linux and macOS. The Bluetooth
 interface must be set up according to your operating system (OS). Generally it
 is as simple as using the Bluetooth interface of your OS in order to discover
 and to pair the e-puck as a regular Bluetooth device. The complete instructions

--- a/guide/using-webots-makefiles.md
+++ b/guide/using-webots-makefiles.md
@@ -103,7 +103,7 @@ LIBRARIES = -L"C:\Users\YourName\XYZLib\lib" -lXYZLib
 The first line tells gcc where to look for the *#include<XYZLib.h>* file. The
 second line tells gcc to link the executable controller with the "XYZLib.dll"
 and where that ".dll" can be found. Note that this would be similar on Linux and
-Mac OS X, you would just need to use UNIX-compatible paths instead. If more
+macOS, you would just need to use UNIX-compatible paths instead. If more
 external libraries are required, it is always possible to use additional `-I,
 -L` and `-l` flags. For more information on these flags, please refer to the
 `gcc` man page.

--- a/guide/web-scene.md
+++ b/guide/web-scene.md
@@ -64,7 +64,7 @@ The `X3DOM` shadows may have aliasing artifacts or can appear brighter than the 
 The Webots player is using internally the `X3DOM` library (based on `WebGL`).
 
 `X3DOM` is supported in recent versions of Firefox, Chrome, Edge, Internet Explorer and Safari on
-Mac OS X (see details on the [X3DOM website](http://www.x3dom.org)).
+macOS (see details on the [X3DOM website](http://www.x3dom.org)).
 In case of related issues, make sure that `WebGL` is enabled in your Web browser settings.
 
 **Note**:

--- a/reference/index.md
+++ b/reference/index.md
@@ -39,7 +39,7 @@ K-Team S.A.
 
 *Linux*<sup>TM</sup> is a registered trademark of Linus Torvalds.
 
-*Mac OS X*<sup>TM</sup> is a registered trademark of Apple Inc.
+*macOS*<sup>TM</sup> is a registered trademark of Apple Inc.
 
 *Mindstorms*<sup>TM</sup> and *LEGO*<sup>TM</sup> are registered trademarks of
 the LEGO group.

--- a/reference/joystick.md
+++ b/reference/joystick.md
@@ -92,7 +92,7 @@ int wb_joystick_get_pressed_button();
 **Description**
 
 This function allows you to read a button pressed on the joystick paired with this controller (if any). The Webots window must be selected and the simulation must be running.
-All the buttons pressed can be read by calling the `wb_joystick_get_key()` function repeatedly until this function returns -1. The returned value, if non-negative, is a button code corresponding to a button currently pressed. If no button is currently pressed, the function will return -1. Calling the `wb_joystick_get_key()` function a second time will return either -1 or the button code of another button which is currently simultaneously pressed. On Mac OS X, only the first 12 buttons and first 2 axes of the joystick are taken into account.
+All the buttons pressed can be read by calling the `wb_joystick_get_key()` function repeatedly until this function returns -1. The returned value, if non-negative, is a button code corresponding to a button currently pressed. If no button is currently pressed, the function will return -1. Calling the `wb_joystick_get_key()` function a second time will return either -1 or the button code of another button which is currently simultaneously pressed. On macOS, only the first 12 buttons and first 2 axes of the joystick are taken into account.
 
 ---
 

--- a/reference/plugin-setup.md
+++ b/reference/plugin-setup.md
@@ -12,7 +12,7 @@ plugin in the dialog and then save the ".wbt" file.
 Note that the `WorldInfo.physics` string specifies the name of the plugin source
 and binary files without extension. The extension will be added by Webots
 depending on the platform: it will be ".so" (Linux), ".dll" (Windows) or
-".dylib" (Mac OS X) for the binary file. For example, this
+".dylib" (macOS) for the binary file. For example, this
 [WorldInfo](worldinfo.md) node:
 
 ```


### PR DESCRIPTION
Fixed partially #232

