### PR TITLE
Fix SSL certificates errors on Ubuntu 16.04

### DIFF
--- a/local_exporter.py
+++ b/local_exporter.py
@@ -37,6 +37,7 @@ dependencies = [
     'wwi/8.5/request_methods.js'
 ]
 
+
 def download(url, target_file_path):
     """Download URL to file."""
     print '# downloading %s' % url
@@ -50,14 +51,15 @@ def download(url, target_file_path):
     nTrials = 3
     for i in range(nTrials):
         try:
-            if platform.system() == 'Linux':
-                # On Ubuntu 16.04 there are issues if the certificates are not ignored.
+            if platform.system() == 'Linux' and \
+               int(platform.python_version_tuple()[0]) >= 3:
+                # On Ubuntu 16.04 there are issues with the certificates.
                 ctx = ssl.create_default_context()
                 ctx.check_hostname = False
                 ctx.verify_mode = ssl.CERT_NONE
-               response = urllib2.urlopen(url, timeout=5, context=ctx)
+                response = urllib2.urlopen(url, timeout=5, context=ctx)
             else:
-               response = urllib2.urlopen(url, timeout=5)
+                response = urllib2.urlopen(url, timeout=5)
             content = response.read()
 
             f = open(target_file_path, 'w')
@@ -69,11 +71,11 @@ def download(url, target_file_path):
             print 'HTTPError = ' + str(e.reason)
         except urllib2.URLError, e:
             print 'URLError = ' + str(e.reason)
-        except:
-            if i == nTrials - 1:
-                sys.exit('Cannot get url: ' + url)
+        if i == nTrials - 1:
+            sys.exit('Cannot get url: ' + url)
     if i > 0:
         print '# (number of trials: %d)' % (i + 1)
+
 
 script_directory = os.path.dirname(os.path.realpath(__file__)) + os.sep
 

--- a/local_exporter.py
+++ b/local_exporter.py
@@ -52,8 +52,10 @@ def download(url, target_file_path):
     for i in range(nTrials):
         try:
             if platform.system() == 'Linux' and \
-               int(platform.python_version_tuple()[0]) >= 3:
+               hasattr(ssl, 'create_default_context'):
                 # On Ubuntu 16.04 there are issues with the certificates.
+                # But 'create_default_context' has been introduced in python
+                # 2.7.9 and it is not available on Ubuntu 14.04.
                 ctx = ssl.create_default_context()
                 ctx.check_hostname = False
                 ctx.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
Fix  `local_export.py` on Ubuntu 16.04 (Python 2.7.12):
```
URLError = [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
```

It seems that ssl/urllib2 changed in Python 2.7.9.
The same code doesn't work and it is not needed on Ubuntu 14.04 (Python 2.7.6).

I also fixed the PEP8 warnings.