### PR TITLE
Fix src/math .gitignore file

### DIFF
--- a/src/math/.gitignore
+++ b/src/math/.gitignore
@@ -1,3 +1,4 @@
 /*.pdf
 /*.png
 /*.aux
+/*.log


### PR DESCRIPTION
Before we change the formulas to MathML, typing `make` in `src/math` is generating annoying log files.