### PR TITLE
Cleanup Python spelling

### DIFF
--- a/automobile/openstreetmap-importer.md
+++ b/automobile/openstreetmap-importer.md
@@ -45,7 +45,7 @@ on http://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely and type a cmd terminal:
 
 ## How to use the importer
 
-You should use the `importer.py` python script to generate the `myMap.wbt`
+You should use the `importer.py` Python script to generate the `myMap.wbt`
 webots simulation world from the `myMap.osm` file:
 
 ```sh

--- a/automobile/sumo-exporter.md
+++ b/automobile/sumo-exporter.md
@@ -30,7 +30,7 @@ On Linux, the path to the SUMO binaries directory should be added in your LD\_LI
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$WEBOTS_HOME/projects/automobile/resources/sumo/bin
 ```
 
-You should use the `exporter.py` python script to generate the `sumo.nod.xml`,
+You should use the `exporter.py` Python script to generate the `sumo.nod.xml`,
 `sumo.edg.xml` and `sumo.sumocfg` SUMO files.
 These files can be used by SUMO `netconvert` to generate the `sumo.net.xml` file
 from the `myMap.wbt` webots simulation world.

--- a/automobile/sumo-interface.md
+++ b/automobile/sumo-interface.md
@@ -3,7 +3,7 @@
 An interface with a microscopic traffic simulator called `SUMO` (Simulation of
 Urban MObility) has been developed using a `Supervisor` node. The advantage of
 interfacing SUMO with Webots is that it allows to easily generate traffic using
-a large number of vehicles in real-time. This interface is written in python in
+a large number of vehicles in real-time. This interface is written in Python in
 a supervisor controller and uses  [TraCI](http://sumo.dlr.de/wiki/TraCI) to
 communicate with SUMO.
 

--- a/guide/using-python.md
+++ b/guide/using-python.md
@@ -75,7 +75,7 @@ sudo apt-get install python-pip
 sudo pip install opencv-python
 ```
 
-On Ubuntu 14.04 it doesn't need to be installed because the python OpenCV library is already included in the Ubuntu 14.04 tarball package.
+On Ubuntu 14.04 it doesn't need to be installed because the Python OpenCV library is already included in the Ubuntu 14.04 tarball package.
 
 #### macOS
 


### PR DESCRIPTION
In almost all the documentation files we write Python with upper case P.

:+1: 