### PR TITLE
Fixed documentation on supported MATLAB versions.

### DIFF
--- a/guide/using-matlab.md
+++ b/guide/using-matlab.md
@@ -17,8 +17,8 @@ becomes possible to reuse your existing MATLAB code directly in Webots.
 
 In order to use MATLAB controllers in Webots, the MATLAB software must be
 installed (a MATLAB license is required). Webots {{ webots.version.major }}.{{
-webots.version.minor }}.{{ webots.version.bugfix }} supports only MATLAB version
-2015a (64 bits), R2015b (64 bits) and R2016a.
+webots.version.minor }}.{{ webots.version.bugfix }} supports only MATLAB versions
+2015b (64 bits), R2016a, R2016b and R2017a.
 
 Webots must be able to access the "matlab" executable (usually a script) in
 order to run controller m-files. Webots looks for the "matlab" executable in
@@ -34,7 +34,7 @@ make sure that your *Path* contains this directory (or something slightly
 different, according to your MATLAB version):
 
 ```
-Path=C:\Program Files\MATLAB\R2009b\bin
+Path=C:\Program Files\MATLAB\R2017a\bin
 ```
 
 On Linux, the MATLAB installer normally suggests to add a symlink to the


### PR DESCRIPTION
It turns out version R2015a of MATLAB has problems with Webots 8.6.0, whereas more recent versions of MATLAB work fine. We don't want to fix this. Rather we officially support only version from R2015b on.

*Note*: Mathworks is also giving up on 32 bit versions of MATLAB: https://ch.mathworks.com/fr/support/sysreq/roadmap.html

👍