### PR TITLE
Fix copy of the showdown youtube extension

### DIFF
--- a/local_exporter.py
+++ b/local_exporter.py
@@ -34,6 +34,7 @@ dependencies = [
     'showdown/1.3.0/showdown.js.map',
     'showdown/1.3.0/showdown.min.js',
     'showdown/1.3.0/showdown.min.js.map',
+    'showdown/1.3.0/showdown-youtube.min.js',
     'wwi/8.6/request_methods.js'
 ]
 


### PR DESCRIPTION
Causing failure in the local doc:

![capture d ecran 2017-09-07 a 15 39 06](https://user-images.githubusercontent.com/866788/30166146-ba1af684-93e2-11e7-8330-ddba8b5fd887.png)
