### PR TITLE
Improved verbosity of local_exporter.py

### DIFF
--- a/local_exporter.py
+++ b/local_exporter.py
@@ -9,6 +9,8 @@ import ssl
 import sys
 import urllib2
 
+verbose = len(sys.argv) and (sys.argv[1] == '--verbose')
+
 dependencies = [
     'highlight/9.5.0/default.min.css',
     'highlight/9.5.0/highlight.min.js',
@@ -41,7 +43,8 @@ dependencies = [
 
 def download(url, target_file_path):
     """Download URL to file."""
-    print '# downloading %s' % url
+    if verbose:
+        print ('# downloading %s' % url)
 
     # Prepare the target directory
     target_directory = os.path.dirname(target_file_path)
@@ -72,13 +75,13 @@ def download(url, target_file_path):
 
             break
         except urllib2.HTTPError, e:
-            print 'HTTPError = ' + str(e.reason)
+            sys.stderr.write('HTTPError = ' + str(e.reason))
         except urllib2.URLError, e:
-            print 'URLError = ' + str(e.reason)
+            sys.stderr.write('URLError = ' + str(e.reason))
         if i == nTrials - 1:
             sys.exit('Cannot get url: ' + url)
     if i > 0:
-        print '# (number of trials: %d)' % (i + 1)
+        sys.stderr.write('# (number of trials: %d)' % (i + 1))
 
 
 script_directory = os.path.dirname(os.path.realpath(__file__)) + os.sep

--- a/local_exporter.py
+++ b/local_exporter.py
@@ -9,7 +9,7 @@ import ssl
 import sys
 import urllib2
 
-verbose = len(sys.argv) and (sys.argv[1] == '--verbose')
+silent = len(sys.argv) > 1 and (sys.argv[1] == '--silent')
 
 dependencies = [
     'highlight/9.5.0/default.min.css',
@@ -43,7 +43,7 @@ dependencies = [
 
 def download(url, target_file_path):
     """Download URL to file."""
-    if verbose:
+    if not silent:
         print ('# downloading %s' % url)
 
     # Prepare the target directory


### PR DESCRIPTION
Aim: typing make on Webots root directory is producing interlaced output. Removing the stdout by default is a solution for this.

- print on stdout only if the --verbose argument is given
- print the errors on stderr.