### PR TITLE
Remove description of unrelated fields in JointParameters

### DIFF
--- a/reference/jointparameters.md
+++ b/reference/jointparameters.md
@@ -30,10 +30,6 @@ parameters node, it has no anchor.
 
 - The `position` field represents the current *position* of the joint, in radians or meters. For an hinge, it is the current rotation angle in radians. For a slider, it is the magnitude of the current translation in meters. When changing the `position` field from the Webots scene tree, Webots also changes the corresponding `rotation` (for a hinge) or `translation` (for a slider) field in the `endPoint` solid of the parent joint node to keep the consistency of the model. Similarly, when changing the `position` field of a [JointParameters](#jointparameters) node in a text editor, you should take care of also changing the corresponding `rotation` or `translation` field accordingly.
 
-- The `minPosition` and `maxPosition` fields specify *soft limits* for the target
-position. These fields are described in more detail in the "Joint Limits"
-section, see below.
-
 - The `minStop` and `maxStop` fields specify the position of physical (or
 mechanical) stops. These fields are described in more detail in the "Joint
 Limits" section, see below.


### PR DESCRIPTION
`minPosition`and `maxPosition`are `Motor` fields and not `JointParameters` fields.