### PR TITLE
Add Solid name to PROTO descriptions

### DIFF
--- a/automobile/automobilewheel.md
+++ b/automobile/automobilewheel.md
@@ -14,6 +14,7 @@ PROTO featuring the corresponding `automobileWheel` slots.
 
 ```
 AutomobileWheel {
+  SFString   name               "automobile wheel"
   SFFloat    thickness          0.3
   SFFloat    tireRadius         0.4
   SFInt32    subdivision        24
@@ -36,6 +37,7 @@ AutomobileWheel {
 
 ### AutomobileWheel Field Summary
 
+- `name`: Identifies the wheel.
 - `thickness`: Defines the thickness of the wheel.
 - `tireRadius`: Defines the outer radius of the wheel.
 - `subdivision`: Defines the number of subdivisions for the cylinder

--- a/automobile/billboard.md
+++ b/automobile/billboard.md
@@ -20,6 +20,7 @@ and the side flattened.
 AdvertisingBoard {
   SFVec3f     translation       0 0 0
   SFRotation  rotation          0 1 0 0
+  SFString    name              "advertising board"
   MFString    frontTexture      "textures/webots_billboard.jpg"
   MFString    backTexture       "textures/webots_billboard.jpg"
   MFColor     recognitionColors [ 1 1 1, 0.75 0 0 ]

--- a/automobile/buildings.md
+++ b/automobile/buildings.md
@@ -44,7 +44,7 @@ buildings.
 
 ```
 Building {
-  SFString    name                   ""
+  SFString    name                   "building"
   SFFloat     floorHeight            3
   SFInt32     floorNumber            3
   SFInt32     startingFloor          0
@@ -61,7 +61,6 @@ Building {
 
 #### Building Field Summary
 
-- `name`: Could contain the building name.
 - `floorHeight`: Defines the height of one floor.
 - `floorNumber`: Defines the number of floors (excluding roof).
 - `startingFloor`: Defines the floor number for the "ground floor" of the building, as not all buildings start at the ground floor.

--- a/automobile/radar-sensors.md
+++ b/automobile/radar-sensors.md
@@ -49,7 +49,7 @@ SmsUmrr-0a29/30/31 {
     SFRotation rotation       0 1 0 0
     SFString   name           "sms-umrr"
     SFBool     occlusion      FALSE
-    SFFloat    cellSpeed   0.0
+    SFFloat    cellSpeed      0.0
     SFFloat    angularNoise   0.0
   }
 ```

--- a/automobile/road-segments.md
+++ b/automobile/road-segments.md
@@ -18,7 +18,7 @@ purposes.
 Road {
   SFVec3f    translation                0 0 0
   SFRotation rotation                   0 1 0 0
-  SFString   name                       ""
+  SFString   name                       "road"
   SFString   id                         ""
   SFString   startJunction              ""
   SFString   endJunction                ""
@@ -240,7 +240,7 @@ garage input ramp.
 %end
 
 ```
-Helicoidal {
+HelicoidalRoadSegment {
   SFVec3f    translation               0 0 0
   SFRotation rotation                  0 1 0 0
   SFFloat    width                     7
@@ -292,7 +292,7 @@ The `Crossroad` PROTO represents a crossroad.
 Crossroad {
   SFVec3f    translation      0 0 0
   SFRotation rotation         0 1 0 0
-  SFString   name             ""
+  SFString   name             "crossroad"
   SFString   id               ""
   MFVec3f    shape            [ 0 0 0, 1 0 0, 0 0 1]
   MFString   connectedRoadIDs []
@@ -329,6 +329,7 @@ The `Roundabout` PROTO represents a roundabout intersection.
 Roundabout {
   SFVec3f    translation              0 0 0
   SFRotation rotation                 0 1 0 0
+  SFString   name                     "roundabout"
   SFInt32    subdivision              16
   SFInt32    numberOfLanes            2
   SFBool     bottom                   FALSE
@@ -391,6 +392,7 @@ The `RoadIntersection` PROTO represents a perpendicular intersection.
 RoadIntersection {
   SFVec3f    translation                    0 0 0
   SFRotation rotation                       0 1 0 0
+  SFString   name                           "road intersection"
   SFInt32    roadNumber                     4
   SFFloat    roadsWith                      7
   SFBool     startRoads                     TRUE
@@ -478,6 +480,7 @@ road.
 AddLaneRoadSegment {
   SFVec3f    translation               0 0 0
   SFRotation rotation                  0 1 0 0
+  SFString   name                      "road"
   SFFloat    width                     7
   SFFloat    length                    20
   SFInt32    numberOfLanes             2
@@ -526,6 +529,7 @@ several lanes to the road.
 AddLanesRoadSegment {
   SFVec3f    translation               0 0 0
   SFRotation rotation                  0 1 0 0
+  SFString   name                      "road"
   SFFloat    width                     7
   SFFloat    length                    20
   SFInt32    numberOfLanes             2

--- a/automobile/sumo-interface.md
+++ b/automobile/sumo-interface.md
@@ -58,6 +58,7 @@ Here are the parameters of the `SumoInterface` PROTO (which inherits from the `S
 
 ```
 PROTO SumoInterface [
+  field SFString  name                  "sumo interface"
   field SFBool    gui                   TRUE
   field SFBool    useNetconvert         TRUE
   field SFBool    enableTrafficLights   TRUE

--- a/reference/procedural-proto-nodes.md
+++ b/reference/procedural-proto-nodes.md
@@ -121,6 +121,7 @@ This tag should not be used if the result of the PROTO depends on something else
 PROTO SimpleStairs [
   field SFVec3f    translation 0 0 0
   field SFRotation rotation    0 1 0 0
+  field SFString   name        "stairs"
   field SFInt32    nSteps      10
   field SFVec3f    stepSize    0.2 0.2 0.8
   field SFColor    color       0 1 0
@@ -198,6 +199,7 @@ PROTO SimpleStairs [
         ]
       }
     ]
+    name IS name
     boundingObject USE SIMPLE_STAIRS_GROUP
     physics IS physics
   }

--- a/reference/proto-definition.md
+++ b/reference/proto-definition.md
@@ -29,6 +29,7 @@ Here is an example of PROTO definition:
 PROTO MyProto [
   field SFVec3f    translation   0 0 0
   field SFRotation rotation      0 1 0 0
+  field SFString   name          "my proto"
   field SFColor    color         0.5 0.5 0.5
   field SFNode     physics       NULL
   field MFNode     extensionSlot []
@@ -62,6 +63,7 @@ For example:
 PROTO Bicycle [
   field SFVec3f    position   0 0 0
   field SFRotation rotation   0 1 0 0
+  field SFString   name       "bicycle"
   field SFColor    frameColor 0.5 0.5 0.5
   field SFBool     hasBrakes  TRUE
 ]

--- a/reference/proto-example.md
+++ b/reference/proto-example.md
@@ -21,6 +21,7 @@ and orientation of the PROTO instances.
 PROTO TwoColorChair [
   field SFVec3f    translation       0 0.91 0
   field SFRotation rotation          0 1 0 0
+  field SFString   name              "two-color chair"
   field SFColor    legColor          1 1 0
   field SFColor    seatColor         1 0.65 0
   field SFNode     seatGeometry      NULL
@@ -70,6 +71,7 @@ PROTO TwoColorChair [
         children [ USE LEG_SHAPE ]
       }
     ]
+    name IS name
   }
 }
 ```


### PR DESCRIPTION
Related to https://github.com/omichel/webots/pull/6380: update description of PROTO nodes to include the Solid.name parameter.