### PR TITLE
Fixed the display of branches and tag based documentation versions

### DIFF
--- a/doc.php
+++ b/doc.php
@@ -15,22 +15,15 @@
     if ($j === FALSE) {
       $page = substr($uri, $i + 1);
       $branch = '';
-      $tag = '';
     } else {
       $page = substr($uri, $i + 1, $j - $i - 1);
       $version = substr($uri, $j + 9);
-      if (preg_match('/^\d+\.\d*(.)+$/',$version)) {
-        $branch = '';
-        $tag = $version;
-      } else {
-        $n = strpos($version, ':');
-        if ($n === FALSE)
-          $branch = $version;
-        else {
-          $branch = substr($version, $n + 1);
-          $repository = substr($version, 0, $n);
-        }
-        $tag = '';
+      $n = strpos($version, ':');
+      if ($n === FALSE)
+        $branch = $version;
+      else {
+        $branch = substr($version, $n + 1);
+        $repository = substr($version, 0, $n);
       }
     }
   } else {
@@ -38,7 +31,6 @@
     $book = $uri;
     $page = 'index';
     $branch = '';
-    $tag = '';
     # anchor is not sent to the server, so it has to be computed by the javascript
   }
   if (!isset($repository))
@@ -58,7 +50,6 @@
         'page':   '$page',
         'anchor': extractAnchor(),
         'branch': '$branch',
-        'tag':    '$tag',
         'repository': '$repository',
         'url':    'https://raw.githubusercontent.com/$repository/webots-doc/'
       }

--- a/js/viewer.js
+++ b/js/viewer.js
@@ -27,15 +27,11 @@ function setupCyberboticsUrl(url) {
     m = url.match(/version=([^&#]*)/);
     if (m) {
       var version = m[1];
-      if (version.match(/^\d+\.\d*(.)+$/))
-        setup.tag = version;
-      else {
-        var n = version.indexOf(':');
-        if (n == -1)
-          setup.branch = version;
-        else
-          setup.branch = version.substr(n + 1);
-      }
+      var n = version.indexOf(':');
+      if (n == -1)
+        setup.branch = version;
+      else
+        setup.branch = version.substr(n + 1);
     }
 
     m = arguments.match(/#([^&#]*)/);
@@ -47,8 +43,6 @@ function setupCyberboticsUrl(url) {
 }
 
 function setupDefaultUrl(url) {
-    setup.tag = '';
-
     var m;
 
     m = url.match(/page=([^&#]*)/);
@@ -75,7 +69,7 @@ function setupUrl(url) {
         setupCyberboticsUrl(url);
     else
         setupDefaultUrl(url);
-    console.log("book="+setup.book+" page="+setup.page+" branch="+setup.branch+" tag="+setup.tag+" anchor="+setup.anchor);
+    console.log("book="+setup.book+" page="+setup.page+" branch="+setup.branch+" anchor="+setup.anchor);
 }
 
 function computeTargetPath() {
@@ -123,11 +117,7 @@ function forgeUrl(page, anchor) {
   var newUrl = currentUrl;
   if (isCyberboticsUrl) {
     newUrl = "https://www.cyberbotics.com/doc/" + setup.book + "/" + page;
-    if (setup.tag != '' && setup.repository && setup.repository != "omichel")
-      newUrl += "?version=" + setup.repository + ":" + setup.tag;
-    else if (setup.tag != '')
-      newUrl += "?version=" + setup.tag;
-    else if (setup.branch != '' && setup.repository && setup.repository != "omichel")
+    if (setup.branch != '' && setup.repository && setup.repository != "omichel")
       newUrl += "?version=" + setup.repository + ":" + setup.branch;
     else if (setup.branch != '')
       newUrl += "?version=" + setup.branch;
@@ -276,6 +266,8 @@ function setUpBlogStyleIfNeeded() {
 }
 
 function getWebotsVersion() {
+  if (setup.branch)
+    return setup.branch;
   // Get the Webots version from the showdown wbVariables extension
   var version = "{{ webots.version.full }}";
   var converter = new showdown.Converter({extensions: ["wbVariables"]});


### PR DESCRIPTION
Address https://github.com/omichel/webots/issues/6539

The current system seems to be broken as:
1. it expects that tags are set properly in webots-doc, which is not the case.
2. it recognizes the version number from the `major.minor.maintenance` template which doesn't work any more with `R2018a`.
3. it uses both the tag and branch concept which is over-complicated for your purposes (see below).

Nothing has to be changed on the Webots side as the links to the online documentation are properly generated with the correct version number, corresponding to the version of Webots currently in use.

The concept of "tag" in the documentation script seems to be useless. Actually we can access raw content of github branches and tags exactly the same way. So, we can simplify our script and store the branch name only (which may also be a tag name).

Also the `getWebotsVersion()` will return the branch/tag name if specified or the current version if not specified, which is exactly what to want to display on the web page.

Unfortunately, it is possible to test these scripts until they are actually in production. I quickly tested them and they appear to behave nicely between Webots 8.5, 8.6 and Webots R2018a.

I will now add the tags for Webots 8.5.