### PR TITLE
Fix RawGit Not Refreshing Resources on Master

### DIFF
--- a/doc.php
+++ b/doc.php
@@ -59,8 +59,7 @@
         'anchor':     window.location.hash.substring(1),
         'branch':     '$branch',
         'repository': '$repository',
-        'url':        'https://raw.githubusercontent.com/$repository/webots-doc/',
-        'rawgiturl':  '$rawgiturl'
+        'url':        'https://raw.githubusercontent.com/$repository/webots-doc/'
       }
       console.log('Setup: ' + JSON.stringify(setup));
     </script>

--- a/doc.php
+++ b/doc.php
@@ -36,21 +36,21 @@
   if (!isset($repository))
     $repository = 'omichel';
 
-  # get HEAD commit SHA, to ensure that when master is updated the latest version is cached by the CDN
-  ini_set('user_agent', 'omichel'); # every GitHub request needs a valid user agent header
-  $githubHead = file_get_contents("https://api.github.com/repos/omichel/webots-doc/git/refs/heads/master");
-  // failed request / github is down
-  if ($githubHead === FALSE)
-    $sha = "master";
-  else {
-    $githubPhp = json_decode($githubHead);
-    $sha = $githubPhp->object->sha;
-  }
+  if ($branch === '') {
+    # get HEAD commit SHA, to ensure that when master is updated the latest version is cached by the CDN
+    ini_set('user_agent', 'omichel'); # every GitHub request needs a valid user agent header
+    $githubHead = file_get_contents("https://api.github.com/repos/omichel/webots-doc/git/refs/heads/master");
+    // failed request / github is down
+    if ($githubHead === FALSE)
+      $rawgiturl = "https://rawgit.com/$repository/webots-doc/master"; //fall back to dev URL at worst
+    else {
+      $githubPhp = json_decode($githubHead);
+      $sha = $githubPhp->object->sha;
+      $rawgiturl = "https://cdn.rawgit.com/$repository/webots-doc/$sha";  // Load the current master snapshot from RawGit CDN.
+    }
+  } else
+    $rawgiturl = "https://rawgit.com/$repository/webots-doc/"; // Load master snapshot from dev URL.
 
-  if ($branch === '')
-    $rawgiturl = "https://cdn.rawgit.com/$repository/webots-doc/$sha";  // RawGit production URL.
-  else
-    $rawgiturl = "https://rawgit.com/$repository/webots-doc/"; // RawGit development URL.
   $scripts="
     <script>
       setup = {

--- a/doc.php
+++ b/doc.php
@@ -35,8 +35,20 @@
   }
   if (!isset($repository))
     $repository = 'omichel';
+
+  # get HEAD commit SHA, to ensure that when master is updated the latest version is cached by the CDN
+  ini_set('user_agent', 'omichel'); # every GitHub request needs a valid user agent header
+  $githubHead = file_get_contents("https://api.github.com/repos/omichel/webots-doc/git/refs/heads/master");
+  // failed request / github is down
+  if ($githubHead === FALSE)
+    $sha = "master";
+  else {
+    $githubPhp = json_decode($githubHead);
+    $sha = $githubPhp->object->sha;
+  }
+
   if ($branch === '')
-    $rawgiturl = "https://cdn.rawgit.com/$repository/webots-doc/master/";  // RawGit production URL.
+    $rawgiturl = "https://cdn.rawgit.com/$repository/webots-doc/$sha";  // RawGit production URL.
   else
     $rawgiturl = "https://rawgit.com/$repository/webots-doc/"; // RawGit development URL.
   $scripts="
@@ -47,7 +59,8 @@
         'anchor':     window.location.hash.substring(1),
         'branch':     '$branch',
         'repository': '$repository',
-        'url':        'https://raw.githubusercontent.com/$repository/webots-doc/'
+        'url':        'https://raw.githubusercontent.com/$repository/webots-doc/',
+        'rawgiturl':  '$rawgiturl'
       }
       console.log('Setup: ' + JSON.stringify(setup));
     </script>


### PR DESCRIPTION
fixes #589.

This PR ensures that when a commit is added to `master` the RawGit CDN resources are refreshed, avoiding the CDN caching mechanism which caches a given URL once *permanently*.