### PR TITLE
Fix cariage returns after etc. statements

### DIFF
--- a/guide/using-python.md
+++ b/guide/using-python.md
@@ -18,7 +18,8 @@ As a consequence, it executes the first `python` binary found in the current `PA
 If you want to use a different version of Python, please install it if needed and configure your environment so that it becomes the default `python` version when called from the command line in a terminal.
 Alternatively, you can change the default Python command from the Webots Preferences in the General tab.
 If you set it for example to `python3.6` instead of `python`, this version of python will be used (if available from the command line).
-Finally, it is also possible to set a different version of Python for each robot controller by editing the `[python]` section of the `runtime.ini` file in each robot controller directory and setting the `COMMAND` value to `python3`, `python3.6` or `python2.7`, etc. If specified in the `runtime.ini` file of a controller, this Python command will be executed instead of the default one to launch this controller.
+Finally, it is also possible to set a different version of Python for each robot controller by editing the `[python]` section of the `runtime.ini` file in each robot controller directory and setting the `COMMAND` value to `python3`, `python3.6` or `python2.7`, etc.
+If specified in the `runtime.ini` file of a controller, this Python command will be executed instead of the default one to launch this controller.
 
 #### macOS and Linux installation
 

--- a/reference/differentialwheels.md
+++ b/reference/differentialwheels.md
@@ -107,7 +107,8 @@ Friction is not simulated, so a [DifferentialWheels](#differentialwheels) does n
 Instead, its motion is controlled by a 2D kinematics algorithm using the `axleLength, wheelRadius` and `maxAcceleration` fields.
 Because friction is not simulated the [DifferentialWheels](#differentialwheels) will not slide on a wall or on another robot.
 The simulation will rather look as if obstacles (walls, robots, etc.) are very rough or harsh.
-However the robots can normally avoid to become blocked by changing direction, rotating the wheels backwards, etc. Unlike the "physics" mode, in the "kinematics" mode the gravity and other forces are not simulated therefore a [DifferentialWheels](#differentialwheels) robot will keep its initial elevation throughout the simulation.
+However the robots can normally avoid to become blocked by changing direction, rotating the wheels backwards, etc.
+Unlike the "physics" mode, in the "kinematics" mode the gravity and other forces are not simulated therefore a [DifferentialWheels](#differentialwheels) robot will keep its initial elevation throughout the simulation.
 
 %figure "DifferentialWheels simulation modes"
 

--- a/reference/introduction-of-the-physics-plugins.md
+++ b/reference/introduction-of-the-physics-plugins.md
@@ -3,6 +3,7 @@
 This chapter describes Webots capability to add a physics plugin to a simulation.
 A physics plugin is a user-implemented shared library which is loaded by Webots at run-time, and which gives access to the low-level API of the [ODE](http://www.ode.org) physics engine.
 A physics plugin can be used, for example, to gather information about the simulated bodies (position, orientation, linear or angular velocity, etc.), to add forces and torques, to add extra joints, e.g., "ball & socket" or "universal joints" to a simulation.
-For example with a physics plugin it is possible to design an aerodynamics model for a flying robot, a hydrodynamics model for a swimming robot, etc. Moreover, with a physics plugin you can implement your own collision detection system and define non-uniform friction parameters on some surfaces.
+For example with a physics plugin it is possible to design an aerodynamics model for a flying robot, a hydrodynamics model for a swimming robot, etc.
+Moreover, with a physics plugin you can implement your own collision detection system and define non-uniform friction parameters on some surfaces.
 Note that physics plugins can be programmed only in C or C++.
 Webots PRO is necessary to program physics plugins.


### PR DESCRIPTION
Some missing carriage returns after `etc.` where remaining.