### PR TITLE
Fix Node Hierarchy

### DIFF
--- a/reference/accelerometer.md
+++ b/reference/accelerometer.md
@@ -1,6 +1,6 @@
 ## Accelerometer
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md). and [Solid](solid.md).
 
 ```
 Accelerometer {
@@ -8,7 +8,7 @@ Accelerometer {
   SFBool  xAxis       TRUE   # {TRUE, FALSE}
   SFBool  yAxis       TRUE   # {TRUE, FALSE}
   SFBool  zAxis       TRUE   # {TRUE, FALSE}
-  SFFloat resolution  -1     # [0, inf) 
+  SFFloat resolution  -1     # [0, inf)
 }
 ```
 

--- a/reference/accelerometer.md
+++ b/reference/accelerometer.md
@@ -1,6 +1,6 @@
 ## Accelerometer
 
-Derived from [Device](device.md) and [Solid](solid.md). and [Solid](solid.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Accelerometer {

--- a/reference/camera.md
+++ b/reference/camera.md
@@ -1,6 +1,6 @@
 ## Camera
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Camera {

--- a/reference/compass.md
+++ b/reference/compass.md
@@ -1,6 +1,6 @@
 ## Compass
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Compass {

--- a/reference/connector.md
+++ b/reference/connector.md
@@ -1,6 +1,6 @@
 ## Connector
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Connector {

--- a/reference/device.md
+++ b/reference/device.md
@@ -1,6 +1,6 @@
 ## Device
 
-Abstract node, derived from [Solid](solid.md).
+Abstract node.
 
 ```
 Device {

--- a/reference/display.md
+++ b/reference/display.md
@@ -1,6 +1,6 @@
 ## Display
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Display {

--- a/reference/distancesensor.md
+++ b/reference/distancesensor.md
@@ -1,6 +1,6 @@
 ## DistanceSensor
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 DistanceSensor {

--- a/reference/emitter.md
+++ b/reference/emitter.md
@@ -1,6 +1,6 @@
 ## Emitter
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Emitter {

--- a/reference/gps.md
+++ b/reference/gps.md
@@ -1,6 +1,6 @@
 ## GPS
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 GPS {

--- a/reference/gyro.md
+++ b/reference/gyro.md
@@ -1,6 +1,6 @@
 ## Gyro
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Gyro {

--- a/reference/inertialunit.md
+++ b/reference/inertialunit.md
@@ -1,6 +1,6 @@
 ## InertialUnit
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 InertialUnit {

--- a/reference/led.md
+++ b/reference/led.md
@@ -1,6 +1,6 @@
 ## LED
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 LED {

--- a/reference/lidar.md
+++ b/reference/lidar.md
@@ -1,6 +1,6 @@
 ## Lidar
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Lidar {

--- a/reference/lightsensor.md
+++ b/reference/lightsensor.md
@@ -1,6 +1,6 @@
 ## LightSensor
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 LightSensor {

--- a/reference/pen.md
+++ b/reference/pen.md
@@ -1,6 +1,6 @@
 ## Pen
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Pen {

--- a/reference/radar.md
+++ b/reference/radar.md
@@ -1,6 +1,6 @@
 ## Radar
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Radar {

--- a/reference/rangefinder.md
+++ b/reference/rangefinder.md
@@ -1,6 +1,6 @@
 ## RangeFinder
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 RangeFinder {

--- a/reference/receiver.md
+++ b/reference/receiver.md
@@ -1,6 +1,6 @@
 ## Receiver
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Receiver {

--- a/reference/speaker.md
+++ b/reference/speaker.md
@@ -1,6 +1,6 @@
 ## Speaker
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Speaker {

--- a/reference/touchsensor.md
+++ b/reference/touchsensor.md
@@ -1,6 +1,6 @@
 ## TouchSensor
 
-Derived from [Device](device.md).
+Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 TouchSensor {


### PR DESCRIPTION
It was wrong to say that `Device` derived from `Solid`, it is not the case and could lead the user to think that any device have all the solid fields.