### PR TITLE
Responsive robot list

### DIFF
--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -291,6 +291,7 @@
   line-height: 140%;
 }
 .webots-doc img {
+  max-width: 100%;
   max-height: 500px;
   vertical-align: middle;
 }
@@ -324,6 +325,7 @@
   border-style: solid;
   border-color: #ddd;
   background-color: #ddd;
+  word-wrap: break-word;
 }
 .webots-doc #view table tr:hover td {
   background-color: #def;


### PR DESCRIPTION
The robot list doesn't support well small windows size because of the image max-width and of the table header wrap.

Without patch:

https://www.cyberbotics.com/doc/guide/robots
![without patch](https://user-images.githubusercontent.com/866788/37292665-a6bd33b0-2611-11e8-8433-1e8af8b21555.png)

With patch:

https://www.cyberbotics.com/doc/guide/robots?version=enhancement-responsive-robot-list
![with patch](https://user-images.githubusercontent.com/866788/37292668-a7385bd0-2611-11e8-9068-cd740c7c27c5.png)
