### PR TITLE
Added PROTO design guidelines

### DIFF
--- a/reference/menu.md
+++ b/reference/menu.md
@@ -101,6 +101,7 @@
     - [Using PROTO Nodes with the Scene Tree](using-proto-nodes-with-the-scene-tree.md)
     - [PROTO Scoping Rules](proto-scoping-rules.md)
     - [PROTO Hidden Fields](proto-hidden-fields.md)
+    - [PROTO Design Guidelines](proto-design-guidelines.md)
 - [Physics Plugin](physics-plugin.md)
     - [Introduction of the Physics Plugins](introduction-of-the-physics-plugins.md)
     - [Plugin Setup](plugin-setup.md)

--- a/reference/proto-design-guidelines.md
+++ b/reference/proto-design-guidelines.md
@@ -30,10 +30,11 @@ A license file may be added in the same folder as the PROTO file if needed.
 #### Tags
 
 If needed, the `tags:` comment should be properly specified.
-It currently supports two possible options: `static` and `hidden` which may be used simultaneously separated with a coma.
-The `static` tag is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) section.
+It currently supports three possible options: `deprecated`, `hidden` and `static` which may be used simultaneously separated with a coma.
+The `deprecated` tag means this PROTO should not be used any more in new simulations, but is kept for backwards compatibility. When using a deprecated PROTO, Webots will display a warning message about it.
 The `hidden` tag tells Webots not to display this PROTO in the Add Node dialog when the user wants to insert a new PROTO.
 Hidden PROTO nodes are typically used as sub-PROTO nodes, that is they are used from another PROTO file, but not directly from a world file.
+The `static` tag is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) section.
 
 #### Description
 

--- a/reference/proto-design-guidelines.md
+++ b/reference/proto-design-guidelines.md
@@ -19,35 +19,38 @@ The first line of a PROTO file is called the header.
 It should be the following: `#VRML_SIM {{ webots.version.major }} utf8`.
 `{{ webots.version.major }}` corresponds to the version of Webots needed to run this PROTO.
 It should be followed by a number of comments describing the PROTO.
-These comments should be formatted as described below to be displayed properly by Webots.
+These comments should be formatted as described in the [example](#example) below to be displayed properly by Webots.
 
 #### License
 
 If a PROTO is meant to be distributed, it is important to specify the license under which it can be used.
-For that purpose, the name of the license should be referred to in the `license:` comment (see example below).
+For that purpose, the name of the license should be referred to in the `license:` comment (see [example](#example) below).
 A license file may be added in the same folder as the PROTO file if needed.
 
 #### Tags
 
 If needed, the `tags:` comment should be properly specified.
-It currently supports three possible options: `deprecated`, `hidden` and `static` which may be used simultaneously separated with a coma.
-The `deprecated` tag means this PROTO should not be used any more in new simulations, but is kept for backwards compatibility. When using a deprecated PROTO, Webots will display a warning message about it.
-The `hidden` tag tells Webots not to display this PROTO in the Add Node dialog when the user wants to insert a new PROTO.
+It currently supports three possible options: `deprecated`, `hidden` and `static` which may be used simultaneously separated with a coma:
+- `deprecated` means this PROTO should not be used any more in new simulations, but is kept for backwards compatibility. When using a deprecated PROTO, Webots will display a warning message about it.
+- `hidden` tells Webots not to display this PROTO in the Add Node dialog when the user wants to insert a new PROTO.
 Hidden PROTO nodes are typically used as sub-PROTO nodes, that is they are used from another PROTO file, but not directly from a world file.
-The `static` tag is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) section.
+- `static` is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) section.
 
 #### Description
 
 Finally, it is important to provide a short description about what the PROTO is about.
-This may be very simple as in the example provided below.
+This may be very simple as in the [example](#example) below.
 This information is displayed in the Add Node dialog to describe the PROTO.
 
 ### Recommended Fields for Simple PROTO Nodes
 
+This section describes simple PROTO nodes representing real world objects, which are derived from the `Solid` node.
+It doesn't cover PROTO nodes derived from other primitives (such as geometries) and complex PROTO nodes such as sensors, actuators or robots.
+
 #### "translation" and "rotation"
 
-PROTO nodes are usually meant to represent real world objects, that can be placed at different locations and orientations in the world.
-Therefore a PROTO should expose at least a `translation` and a `rotation` field to allow the users to move and rotate the object easily.
+Real objects can be placed at different locations and orientations in the world.
+Therefore the corresponding PROTO should expose at least a `translation` and a `rotation` field to allow the users to move and rotate the object easily.
 The default value for the translation should be preferably the origin (0, 0, 0) and should correspond to the object in a normal position, e.g., laying on the floor rather than sinking into the floor.
 That means the origin of an object should not be at its 3D geometrical center, but rather in the middle of the surface in contact with the floor.
 The rotation axis should be already well positioned, e.g., usually vertical, so that when you rotate a building for example, you should simply change the angle value to have it rotate along its vertical axis.

--- a/reference/proto-design-guidelines.md
+++ b/reference/proto-design-guidelines.md
@@ -6,6 +6,10 @@ When creating your own PROTO nodes, we recommend that you follow these guideline
 
 The naming of a PROTO node is important and should be precise and explicit. Therefore, you should avoid abbreviations, numbers and vague terminology when naming a PROTO node. For example `SmallWoodenChair` is better than `SmallChair`, which is better than `Chair`, which is better than `Chair7`. PROTO names should use upper camel case, e.g., each word should begin with a capital letter with no intervening spaces.
 
+### Description
+
+If a PROTO is meant to be distributed, it is important to specify the license under which it can be used. For that purpose, the name of the license should be referred to in the `license:` comment. A license file may be added in the same folder as the PROTO file if needed. Also, the `tags:` comment should be properly specified, see details in the [Procedural PROTO nodes](procedural-proto-nodes.md) section. Finally, it is important to provide a short description about what the PROTO node is about. This may be very simple as in the example provided below.
+
 ### Recommended Fields for Object PROTO Nodes
 
 #### "translation" and "rotation"
@@ -35,6 +39,11 @@ Generally, the number of exposed fields should be minimal in order to guarantee 
 Here is a simple example of a good PROTO declaration:
 
 ```
+#VRML_SIM R2018b utf8
+# license: Creative Commons Attribution 4.0 International License
+# tags: static
+# A color pencil
+
 ColorPencil {
   SFFloat    translation          0 0 0
   SFRotation rotation             0 1 0 0
@@ -43,4 +52,5 @@ ColorPencil {
   SFColor    color                1 0 0     # defaults to red
   SFFloat    size                 0.2       # range in [0.02, 0.2]
 }
+...
 ```

--- a/reference/proto-design-guidelines.md
+++ b/reference/proto-design-guidelines.md
@@ -5,8 +5,8 @@ This ensures that your new PROTO nodes will be well designed, easy-to-use and co
 
 ### Naming
 
-The naming of a PROTO node is important and should be precise and explicit.
-Therefore, you should avoid abbreviations, numbers and vague terminology when naming a PROTO node.
+The naming of a PROTO is important and should be precise and explicit.
+Therefore, you should avoid abbreviations, numbers and vague terminology when naming a PROTO.
 For example `SmallWoodenChair` is better than `SmallChair`, which is better than `Chair`, which is better than `Chair7`.
 PROTO names should use upper camel case, e.g., each word should begin with a capital letter with no intervening spaces.
 
@@ -30,22 +30,23 @@ A license file may be added in the same folder as the PROTO file if needed.
 #### Tags
 
 If needed, the `tags:` comment should be properly specified.
-It currently supports two possible tags: `static` and `hidden` which may be used simultaneously separated with a coma.
+It currently supports two possible options: `static` and `hidden` which may be used simultaneously separated with a coma.
 The `static` tag is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) section.
-The `hidden` tag tells Webots not to display this PROTO node in the Add Node dialog when the user wants to insert a new PROTO node.
-Hidden PROTO nodes are typically used as sub-PROTO nodes, that is they are used from another PROTO node, but not directly from a world file.
+The `hidden` tag tells Webots not to display this PROTO in the Add Node dialog when the user wants to insert a new PROTO.
+Hidden PROTO nodes are typically used as sub-PROTO nodes, that is they are used from another PROTO file, but not directly from a world file.
 
 #### Description
 
-Finally, it is important to provide a short description about what the PROTO node is about.
+Finally, it is important to provide a short description about what the PROTO is about.
 This may be very simple as in the example provided below.
+This information is displayed in the Add Node dialog to describe the PROTO.
 
-### Recommended Fields for Object PROTO Nodes
+### Recommended Fields for Simple PROTO Nodes
 
 #### "translation" and "rotation"
 
 PROTO nodes are usually meant to represent real world objects, that can be placed at different locations and orientations in the world.
-Therefore a PROTO node should expose at least a `translation` and a `rotation` field to allow the users to move and rotate the object easily.
+Therefore a PROTO should expose at least a `translation` and a `rotation` field to allow the users to move and rotate the object easily.
 The default value for the translation should be preferably the origin (0, 0, 0) and should correspond to the object in a normal position, e.g., laying on the floor rather than sinking into the floor.
 That means the origin of an object should not be at its 3D geometrical center, but rather in the middle of the surface in contact with the floor.
 The rotation axis should be already well positioned, e.g., usually vertical, so that when you rotate a building for example, you should simply change the angle value to have it rotate along its vertical axis.
@@ -54,7 +55,7 @@ The rotation axis should be already well positioned, e.g., usually vertical, so 
 
 Bounding objects are used for collision detection.
 If you believe that an object won't collide with anything, it is convenient to be able to turn off collision detection to save computation time.
-Providing a PROTO node with a `enableBoundingObject` boolean field deserves this purpose.
+Providing a PROTO with a `enableBoundingObject` boolean field deserves this purpose.
 For example, in a scenario where a small robot is running on a table top in a living room, all the objects outside of the range of the robot, like the sofa, chairs, chandelier, TV set, etc. will never collide with the robot and hence could have their collision detection disabled.
 However, in some other scenarios, we want that the robot can collide with a chair, because the robot is running on the floor.
 Therefore such objects should have a `enableBoundingObject` field exposed to allow the users to decide whether they want to enable collision detection, depending on the specific simulation scenario.
@@ -80,15 +81,15 @@ Nevertheless, such a `size` field should be limited to a minimal and a maximal s
 Therefore it could be either a floating point or an integer value.
 
 For some PROTO nodes, it could be useful to expose a `color` field.
-For example, a car or a color pencil PROTO node could have a `color` field exposed.
+For example, a car or a color pencil PROTO could have a `color` field exposed.
 However, that should be limited to objects that are available in different colors.
 For example, it should not be used for a fire hydrant (usually always red) or a fork (usually always metallic grey).
 The `color` field may be specified as a `Color` node if any color is available or as a string (if only a limited number of colors is available for that object).
 
 Depending on the object, a number of texture fields may be useful.
-For example a painting PROTO node could have the painting specified in a `picture` field and the frame texture specified in a `frame` field.
+For example a painting PROTO could have the painting specified in a `picture` field and the frame texture specified in a `frame` field.
 
-Generally, the number of exposed fields should be minimal in order to guarantee that the resulting object will be realistic and correspond to the original idea of the PROTO node.
+Generally, the number of exposed fields should be minimal in order to guarantee that the resulting object will be realistic and correspond to the original idea of the PROTO.
 Also, floating point and integer values should be generally constrained between a minimum and a maximum value to ensure a realistic and stable result.
 
 ### Example

--- a/reference/proto-design-guidelines.md
+++ b/reference/proto-design-guidelines.md
@@ -31,10 +31,10 @@ A license file may be added in the same folder as the PROTO file if needed.
 
 If needed, the `tags:` comment should be properly specified.
 It currently supports three possible options: `deprecated`, `hidden` and `static` which may be used simultaneously separated with a coma:
-- The `deprecated` tag means this PROTO should not be used any more in new simulations, but is kept for backwards compatibility. When using a deprecated PROTO, Webots will display a warning message about it.
-- The `hidden` tag tells Webots not to display this PROTO in the Add Node dialog when the user wants to insert a new PROTO.
+- `deprecated` means this PROTO should not be used any more in new simulations, but is kept for backwards compatibility. When using a deprecated PROTO, Webots will display a warning message about it.
+- `hidden` tells Webots not to display this PROTO in the Add Node dialog when the user wants to insert a new PROTO.
 Hidden PROTO nodes are typically used as sub-PROTO nodes, that is they are used from another PROTO file, but not directly from a world file.
-- The `static` tag is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) section.
+- `static` is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) section.
 
 #### Description
 

--- a/reference/proto-design-guidelines.md
+++ b/reference/proto-design-guidelines.md
@@ -1,0 +1,46 @@
+## PROTO Design Guidelines
+
+When creating your own PROTO nodes, we recommend that you follow these guidelines so that your new PROTO nodes will be well designed, easy-to-use and consistent with the existing PROTO nodes provided in Webots.
+
+### Naming
+
+The naming of a PROTO node is important and should be precise and explicit. Therefore, you should avoid abbreviations, numbers and vague terminology when naming a PROTO node. For example `SmallWoodenChair` is better than `SmallChair`, which is better than `Chair`, which is better than `Chair7`. PROTO names should use upper camel case, e.g., each word should begin with a capital letter with no intervening spaces.
+
+### Recommended Fields for Object PROTO Nodes
+
+#### translation and rotation
+
+PROTO nodes are usually meant to represent real world objects, that can be placed at different locations and orientations in the world. Therefore a PROTO node should expose at least a `translation` and a `rotation` field to allow the users to move and rotate the object easily. The default value for the translation should be preferably the origin (0, 0, 0) and should correspond to the object in a normal position, e.g., laying on the floor rather than sinking into the floor. That means the origin of an object should not be at its 3D geometrical center, but rather in the middle of the surface in contact with the floor. The rotation axis should be already well positioned, e.g., usually vertical, so that when you rotate a building for example, you should simply change the angle value to have it rotate along its vertical axis.
+
+#### enableBoundingObject
+
+Bounding objects are used for collision detection. If you believe that an object won't collide with anything, it is convenient to be able to turn off collision detection to save computation time. Providing a PROTO node with a `enableBoundingObject` boolean field deserves this purpose. For example, in a scenario where a small robot is running on a table top in a living room, all the objects outside of the range of the robot, like the sofa, chairs, chandelier, TV set, etc. will never collide with the robot and hence could have their collision detection disabled. However, in some other scenarios, we want that the robot can collide with a chair, because the robot is running on the floor. Therefore such objects should have a `enableBoundingObject` field exposed to allow the users to decide whether they want to enable collision detection, depending on the specific simulation scenario.
+
+#### enablePhysics
+
+Because sometimes, we want to simulate the physical motion of an object and sometimes we want to save computation time by not simulating the physics of the object, it is good also to add a `enablePhysics` boolean field that allows the user to enable or disable physics simulation for an object. For example, a box may be meant to be moveable by a robot or may be glued to the floor or so heavy that it won't move. In that case, it is nice to be able to specify if we want to simulate the physical motion of that object or not. Not simulating the physics saves computation time and increase the stability of the simulation. However, some objects are not meant to move during a simulation. This includes buildings, traffic signs, trees, mailboxes, etc. Therefore such objects should not contain a `Physics` node and obviously should not expose a `enablePhysics` field.
+
+#### Other Fields
+
+In PROTO nodes that correspond to real world objects, it is not recommend to add fields such as `mass` or `scale`. This is because in real life, you cannot change the mass or the size of an object. And we don't want to encourage users of the PROTO nodes to do so, as it may lead to numerical instabilities. Some exceptions however exist. For example, it may be convenient to add a `size` field to a Matryoshka doll PROTO. Nevertheless, such a `size` field should be limited to a minimal and a maximal size or to a limited range of integer values. Therefore it could be either a floating point or an integer value.
+
+For some PROTO nodes, it could be useful to expose a `color` field. For example, a car or a color pencil PROTO node could have a `color` field exposed. However, that should be limited to objects that are available in different colors. For example, it should not be used for a fire hydrant (usually always red) or a fork (usually always metallic grey). The `color` field may be specified as a `Color` node if any color is available or as a string (if only a limited number of colors is available for that object).
+
+Depending on the object, a number of texture fields may be useful. For example a painting PROTO node could have the painting specified in a `picture` field and the frame texture specified in a `frame` field.
+
+Generally, the number of exposed fields should be minimal in order to guarantee that the resulting object will be realistic and correspond to the original idea of the PROTO node. Also, floating point and integer values should be generally constrained between a minimum and a maximum value to ensure a realistic and stable result.
+
+### Example
+
+Here is a simple example of a good PROTO declaration:
+
+```
+ColorPencil {
+  SFFloat    translation          0 0 0
+  SFRotation rotation             0 1 0 0
+  SFBool     enablePhysics        TRUE
+  SFBool     enableBoundingObject TRUE
+  SFColor    color                1 0 0     # defaults to red
+  SFFloat    size                 0.2       # range in [0.02, 0.2]
+}
+```

--- a/reference/proto-design-guidelines.md
+++ b/reference/proto-design-guidelines.md
@@ -31,10 +31,10 @@ A license file may be added in the same folder as the PROTO file if needed.
 
 If needed, the `tags:` comment should be properly specified.
 It currently supports three possible options: `deprecated`, `hidden` and `static` which may be used simultaneously separated with a coma:
-- `deprecated` means this PROTO should not be used any more in new simulations, but is kept for backwards compatibility. When using a deprecated PROTO, Webots will display a warning message about it.
-- `hidden` tells Webots not to display this PROTO in the Add Node dialog when the user wants to insert a new PROTO.
+- The `deprecated` tag means this PROTO should not be used any more in new simulations, but is kept for backwards compatibility. When using a deprecated PROTO, Webots will display a warning message about it.
+- The `hidden` tag tells Webots not to display this PROTO in the Add Node dialog when the user wants to insert a new PROTO.
 Hidden PROTO nodes are typically used as sub-PROTO nodes, that is they are used from another PROTO file, but not directly from a world file.
-- `static` is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) section.
+- The `static` tag is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) section.
 
 #### Description
 

--- a/reference/proto-design-guidelines.md
+++ b/reference/proto-design-guidelines.md
@@ -8,15 +8,15 @@ The naming of a PROTO node is important and should be precise and explicit. Ther
 
 ### Recommended Fields for Object PROTO Nodes
 
-#### `translation` and `rotation`
+#### "translation" and "rotation"
 
 PROTO nodes are usually meant to represent real world objects, that can be placed at different locations and orientations in the world. Therefore a PROTO node should expose at least a `translation` and a `rotation` field to allow the users to move and rotate the object easily. The default value for the translation should be preferably the origin (0, 0, 0) and should correspond to the object in a normal position, e.g., laying on the floor rather than sinking into the floor. That means the origin of an object should not be at its 3D geometrical center, but rather in the middle of the surface in contact with the floor. The rotation axis should be already well positioned, e.g., usually vertical, so that when you rotate a building for example, you should simply change the angle value to have it rotate along its vertical axis.
 
-#### `enableBoundingObject`
+#### "enableBoundingObject"
 
 Bounding objects are used for collision detection. If you believe that an object won't collide with anything, it is convenient to be able to turn off collision detection to save computation time. Providing a PROTO node with a `enableBoundingObject` boolean field deserves this purpose. For example, in a scenario where a small robot is running on a table top in a living room, all the objects outside of the range of the robot, like the sofa, chairs, chandelier, TV set, etc. will never collide with the robot and hence could have their collision detection disabled. However, in some other scenarios, we want that the robot can collide with a chair, because the robot is running on the floor. Therefore such objects should have a `enableBoundingObject` field exposed to allow the users to decide whether they want to enable collision detection, depending on the specific simulation scenario.
 
-#### `enablePhysics`
+#### "enablePhysics"
 
 Because sometimes, we want to simulate the physical motion of an object and sometimes we want to save computation time by not simulating the physics of the object, it is good also to add a `enablePhysics` boolean field that allows the user to enable or disable physics simulation for an object. For example, a box may be meant to be moveable by a robot or may be glued to the floor or so heavy that it won't move. In that case, it is nice to be able to specify if we want to simulate the physical motion of that object or not. Not simulating the physics saves computation time and increase the stability of the simulation. However, some objects are not meant to move during a simulation. This includes buildings, traffic signs, trees, mailboxes, etc. Therefore such objects should not contain a `Physics` node and obviously should not expose a `enablePhysics` field.
 

--- a/reference/proto-design-guidelines.md
+++ b/reference/proto-design-guidelines.md
@@ -1,42 +1,99 @@
 ## PROTO Design Guidelines
 
-When creating your own PROTO nodes, we recommend that you follow these guidelines so that your new PROTO nodes will be well designed, easy-to-use and consistent with the existing PROTO nodes provided in Webots.
+When creating your own PROTO nodes, we recommend that you follow these guidelines.
+This ensures that your new PROTO nodes will be well designed, easy-to-use and consistent with the existing PROTO nodes provided in Webots.
 
 ### Naming
 
-The naming of a PROTO node is important and should be precise and explicit. Therefore, you should avoid abbreviations, numbers and vague terminology when naming a PROTO node. For example `SmallWoodenChair` is better than `SmallChair`, which is better than `Chair`, which is better than `Chair7`. PROTO names should use upper camel case, e.g., each word should begin with a capital letter with no intervening spaces.
+The naming of a PROTO node is important and should be precise and explicit.
+Therefore, you should avoid abbreviations, numbers and vague terminology when naming a PROTO node.
+For example `SmallWoodenChair` is better than `SmallChair`, which is better than `Chair`, which is better than `Chair7`.
+PROTO names should use upper camel case, e.g., each word should begin with a capital letter with no intervening spaces.
 
-### Description
+> **Note**: The PROTO file name should match exactly the PROTO name.
+For example the `SmallWoodenChair` PROTO should be defined in a file named `SmallWoodenChair.proto`.
 
-If a PROTO is meant to be distributed, it is important to specify the license under which it can be used. For that purpose, the name of the license should be referred to in the `license:` comment. A license file may be added in the same folder as the PROTO file if needed. Also, the `tags:` comment should be properly specified, see details in the [Procedural PROTO nodes](procedural-proto-nodes.md) section. Finally, it is important to provide a short description about what the PROTO node is about. This may be very simple as in the example provided below.
+### Header
+
+The first line of a PROTO file is called the header.
+It should be the following: `#VRML_SIM {{ webots.version.major }} utf8`.
+`{{ webots.version.major }}` corresponds to the version of Webots needed to run this PROTO.
+It should be followed by a number of comments describing the PROTO.
+These comments should be formatted as described below to be displayed properly by Webots.
+
+#### License
+
+If a PROTO is meant to be distributed, it is important to specify the license under which it can be used.
+For that purpose, the name of the license should be referred to in the `license:` comment (see example below).
+A license file may be added in the same folder as the PROTO file if needed.
+
+#### Tags
+
+If needed, the `tags:` comment should be properly specified.
+It currently supports two possible tags: `static` and `hidden` which may be used simultaneously separated with a coma.
+The `static` tag is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) section.
+The `hidden` tag tells Webots not to display this PROTO node in the Add Node dialog when the user wants to insert a new PROTO node.
+Hidden PROTO nodes are typically used as sub-PROTO nodes, that is they are used from another PROTO node, but not directly from a world file.
+
+#### Description
+
+Finally, it is important to provide a short description about what the PROTO node is about.
+This may be very simple as in the example provided below.
 
 ### Recommended Fields for Object PROTO Nodes
 
 #### "translation" and "rotation"
 
-PROTO nodes are usually meant to represent real world objects, that can be placed at different locations and orientations in the world. Therefore a PROTO node should expose at least a `translation` and a `rotation` field to allow the users to move and rotate the object easily. The default value for the translation should be preferably the origin (0, 0, 0) and should correspond to the object in a normal position, e.g., laying on the floor rather than sinking into the floor. That means the origin of an object should not be at its 3D geometrical center, but rather in the middle of the surface in contact with the floor. The rotation axis should be already well positioned, e.g., usually vertical, so that when you rotate a building for example, you should simply change the angle value to have it rotate along its vertical axis.
+PROTO nodes are usually meant to represent real world objects, that can be placed at different locations and orientations in the world.
+Therefore a PROTO node should expose at least a `translation` and a `rotation` field to allow the users to move and rotate the object easily.
+The default value for the translation should be preferably the origin (0, 0, 0) and should correspond to the object in a normal position, e.g., laying on the floor rather than sinking into the floor.
+That means the origin of an object should not be at its 3D geometrical center, but rather in the middle of the surface in contact with the floor.
+The rotation axis should be already well positioned, e.g., usually vertical, so that when you rotate a building for example, you should simply change the angle value to have it rotate along its vertical axis.
 
 #### "enableBoundingObject"
 
-Bounding objects are used for collision detection. If you believe that an object won't collide with anything, it is convenient to be able to turn off collision detection to save computation time. Providing a PROTO node with a `enableBoundingObject` boolean field deserves this purpose. For example, in a scenario where a small robot is running on a table top in a living room, all the objects outside of the range of the robot, like the sofa, chairs, chandelier, TV set, etc. will never collide with the robot and hence could have their collision detection disabled. However, in some other scenarios, we want that the robot can collide with a chair, because the robot is running on the floor. Therefore such objects should have a `enableBoundingObject` field exposed to allow the users to decide whether they want to enable collision detection, depending on the specific simulation scenario.
+Bounding objects are used for collision detection.
+If you believe that an object won't collide with anything, it is convenient to be able to turn off collision detection to save computation time.
+Providing a PROTO node with a `enableBoundingObject` boolean field deserves this purpose.
+For example, in a scenario where a small robot is running on a table top in a living room, all the objects outside of the range of the robot, like the sofa, chairs, chandelier, TV set, etc. will never collide with the robot and hence could have their collision detection disabled.
+However, in some other scenarios, we want that the robot can collide with a chair, because the robot is running on the floor.
+Therefore such objects should have a `enableBoundingObject` field exposed to allow the users to decide whether they want to enable collision detection, depending on the specific simulation scenario.
 
 #### "enablePhysics"
 
-Because sometimes, we want to simulate the physical motion of an object and sometimes we want to save computation time by not simulating the physics of the object, it is good also to add a `enablePhysics` boolean field that allows the user to enable or disable physics simulation for an object. For example, a box may be meant to be moveable by a robot or may be glued to the floor or so heavy that it won't move. In that case, it is nice to be able to specify if we want to simulate the physical motion of that object or not. Not simulating the physics saves computation time and increase the stability of the simulation. However, some objects are not meant to move during a simulation. This includes buildings, traffic signs, trees, mailboxes, etc. Therefore such objects should not contain a `Physics` node and obviously should not expose a `enablePhysics` field.
+Because sometimes, we want to simulate the physical motion of an object and sometimes we want to save computation time by not simulating the physics of the object, it is good also to add a `enablePhysics` boolean field that allows the user to enable or disable physics simulation for an object.
+For example, a box may be meant to be moveable by a robot or may be glued to the floor or so heavy that it won't move.
+In that case, it is nice to be able to specify if we want to simulate the physical motion of that object or not.
+Not simulating the physics saves computation time and increase the stability of the simulation.
+However, some objects are not meant to move during a simulation.
+This includes buildings, traffic signs, trees, mailboxes, etc.
+Therefore such objects should not contain a `Physics` node and obviously should not expose a `enablePhysics` field.
 
 #### Other Fields
 
-In PROTO nodes that correspond to real world objects, it is not recommend to add fields such as `mass` or `scale`. This is because in real life, you cannot change the mass or the size of an object. And we don't want to encourage users of the PROTO nodes to do so, as it may lead to numerical instabilities. Some exceptions however exist. For example, it may be convenient to add a `size` field to a Matryoshka doll PROTO. Nevertheless, such a `size` field should be limited to a minimal and a maximal size or to a limited range of integer values. Therefore it could be either a floating point or an integer value.
+In PROTO nodes that correspond to real world objects, it is not recommend to add fields such as `mass` or `scale`.
+This is because in real life, you cannot change the mass or the size of an object.
+And we don't want to encourage users of the PROTO nodes to do so, as it may lead to non-realistic models and numerical instabilities.
+Some exceptions however exist.
+For example, it may be convenient to add a `size` field to a Matryoshka doll PROTO.
+Nevertheless, such a `size` field should be limited to a minimal and a maximal size or to a limited range of integer values.
+Therefore it could be either a floating point or an integer value.
 
-For some PROTO nodes, it could be useful to expose a `color` field. For example, a car or a color pencil PROTO node could have a `color` field exposed. However, that should be limited to objects that are available in different colors. For example, it should not be used for a fire hydrant (usually always red) or a fork (usually always metallic grey). The `color` field may be specified as a `Color` node if any color is available or as a string (if only a limited number of colors is available for that object).
+For some PROTO nodes, it could be useful to expose a `color` field.
+For example, a car or a color pencil PROTO node could have a `color` field exposed.
+However, that should be limited to objects that are available in different colors.
+For example, it should not be used for a fire hydrant (usually always red) or a fork (usually always metallic grey).
+The `color` field may be specified as a `Color` node if any color is available or as a string (if only a limited number of colors is available for that object).
 
-Depending on the object, a number of texture fields may be useful. For example a painting PROTO node could have the painting specified in a `picture` field and the frame texture specified in a `frame` field.
+Depending on the object, a number of texture fields may be useful.
+For example a painting PROTO node could have the painting specified in a `picture` field and the frame texture specified in a `frame` field.
 
-Generally, the number of exposed fields should be minimal in order to guarantee that the resulting object will be realistic and correspond to the original idea of the PROTO node. Also, floating point and integer values should be generally constrained between a minimum and a maximum value to ensure a realistic and stable result.
+Generally, the number of exposed fields should be minimal in order to guarantee that the resulting object will be realistic and correspond to the original idea of the PROTO node.
+Also, floating point and integer values should be generally constrained between a minimum and a maximum value to ensure a realistic and stable result.
 
 ### Example
 
-Here is a simple example of a good PROTO declaration:
+Here is a simple example of a good PROTO declaration (the implementation is not shown):
 
 ```
 #VRML_SIM R2018b utf8

--- a/reference/proto-design-guidelines.md
+++ b/reference/proto-design-guidelines.md
@@ -8,15 +8,15 @@ The naming of a PROTO node is important and should be precise and explicit. Ther
 
 ### Recommended Fields for Object PROTO Nodes
 
-#### translation and rotation
+#### `translation` and `rotation`
 
 PROTO nodes are usually meant to represent real world objects, that can be placed at different locations and orientations in the world. Therefore a PROTO node should expose at least a `translation` and a `rotation` field to allow the users to move and rotate the object easily. The default value for the translation should be preferably the origin (0, 0, 0) and should correspond to the object in a normal position, e.g., laying on the floor rather than sinking into the floor. That means the origin of an object should not be at its 3D geometrical center, but rather in the middle of the surface in contact with the floor. The rotation axis should be already well positioned, e.g., usually vertical, so that when you rotate a building for example, you should simply change the angle value to have it rotate along its vertical axis.
 
-#### enableBoundingObject
+#### `enableBoundingObject`
 
 Bounding objects are used for collision detection. If you believe that an object won't collide with anything, it is convenient to be able to turn off collision detection to save computation time. Providing a PROTO node with a `enableBoundingObject` boolean field deserves this purpose. For example, in a scenario where a small robot is running on a table top in a living room, all the objects outside of the range of the robot, like the sofa, chairs, chandelier, TV set, etc. will never collide with the robot and hence could have their collision detection disabled. However, in some other scenarios, we want that the robot can collide with a chair, because the robot is running on the floor. Therefore such objects should have a `enableBoundingObject` field exposed to allow the users to decide whether they want to enable collision detection, depending on the specific simulation scenario.
 
-#### enablePhysics
+#### `enablePhysics`
 
 Because sometimes, we want to simulate the physical motion of an object and sometimes we want to save computation time by not simulating the physics of the object, it is good also to add a `enablePhysics` boolean field that allows the user to enable or disable physics simulation for an object. For example, a box may be meant to be moveable by a robot or may be glued to the floor or so heavy that it won't move. In that case, it is nice to be able to specify if we want to simulate the physical motion of that object or not. Not simulating the physics saves computation time and increase the stability of the simulation. However, some objects are not meant to move during a simulation. This includes buildings, traffic signs, trees, mailboxes, etc. Therefore such objects should not contain a `Physics` node and obviously should not expose a `enablePhysics` field.
 

--- a/reference/proto-hidden-fields.md
+++ b/reference/proto-hidden-fields.md
@@ -1,7 +1,7 @@
 ## PROTO Hidden Fields
 
 Regular PROTO fields let you change, save and restore, chosen characteristics of your model.
-In constrast, PROTO encapsulation prevents field values which are not accessible through PROTO fields, but which may change during simulation, from being saved and subsequently restored.
+In contrast, PROTO encapsulation prevents field values which are not accessible through PROTO fields, but which may change during simulation, from being saved and subsequently restored.
 Still, this is not true for all field values, since Webots saves for you hidden PROTO fields which are bound to change over simulation time.
 Namely the `translation` and `rotation` fields of [Solid](solid.md) nodes as well as the `position` fields of [Joint](joint.md) nodes are saved as hidden PROTO fields in the field scope of every top-level PROTO.
 In case of [solid merging](physics.md#implicit-solid-merging-and-joints), note that hidden `translation` and `rotation` fields are saved only for the [Solid](solid.md) placed at the top of the solid assembly.
@@ -9,7 +9,7 @@ In case of [solid merging](physics.md#implicit-solid-merging-and-joints), note t
 As in the case of non-PROTO objects, initial velocities of physical subparts of a PROTO are saved and can be subsequently restored when reloading your world file.
 Like the other hidden fields, velocities are saved in the field scope of every top-level PROTO.
 
-Each hidden field appends an index to its name which encodes the location of the [Solid](solid.md) to which it belongs inside the tree hierarchy rooted at the the PROTO node.
+Each hidden field appends an index to its name which encodes the location of the [Solid](solid.md) to which it belongs inside the tree hierarchy rooted at the PROTO node.
 This index corresponds is the depth-first pre-order traversal index of the [Solid](solid.md) in this tree.
 If a hidden field corresponds to the `position` of [Joint](joint.md), an additional index is appended to its name, namely the index of the [Joint](joint.md) in the list of [Joint](joint.md) nodes originating from the [Solid](solid.md) sorted by means of pre-order traversal.
 As an example, we display below an excerpt of "projects/robots/pioneer/pioneer3at/worlds/pioneer3at.wbt" when saved after one simulation step.

--- a/reference/proto.md
+++ b/reference/proto.md
@@ -13,3 +13,4 @@ Once defined, PROTO nodes may be instantiated in the scene tree exactly like bui
 - [Using PROTO nodes with the Scene Tree](using-proto-nodes-with-the-scene-tree.md)
 - [PROTO Scoping Rules](proto-scoping-rules.md)
 - [PROTO hidden fields](proto-hidden-fields.md)
+- [PROTO Design Guidelines](proto-design-guidelines.md)

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -60,7 +60,6 @@ class TestLists(unittest.TestCase):
                 line = re.sub(r'^\s*- ', '', line)  # Remove item prefix.
                 line = re.sub(r'^\s*\d+\. ', '', line)  # Remove number prefix.
                 line = re.sub(TestLists.hyperlinkRE, '', line)  # Remove hyperlinks.
-                line = re.sub(r'`[^`]*`', '', line)  # Remove code.
                 line = line.strip()
                 if len(line) == 0:  # If it remains something, then test it.
                     continue


### PR DESCRIPTION
Add PROTO design guidelines (replaces #724).
Test link: https://www.cyberbotics.com/doc/reference/proto-design-guidelines?version=feature-proto-design-guidelines2