### PR TITLE
Ensure that the first heading level is the biggest one.

### DIFF
--- a/automobile/openstreetmap-importer.md
+++ b/automobile/openstreetmap-importer.md
@@ -1,10 +1,10 @@
-## OpenStreetMap Importer
+# OpenStreetMap Importer
 
 In order to ease the creation of new environments for automobile simulations, Webots worlds can be generated from OpenStreetMap maps using the importer script described here.
 
 You can download an OpenStreetMap map of any part of the world from [www.openstreetmap.org/export](http://www.openstreetmap.org/export) (do not use more than a few square kilometers if you want to be able to run your simulation in real-time) and then save it as a Webots world file (e.g. `myMap.wbt`) using the importer script.
 
-### Movie Presentation
+## Movie Presentation
 
 ![youtube video](https://www.youtube.com/watch?v=tPXHnp4bHrY&t)
 
@@ -96,7 +96,7 @@ You can use several arguments with this script:
 In addition to these arguments, a configuration file can be used to define how to handle most of the OpenStreetMap entities.
 A typical configuration file can be seen in [appendix](a-typical-openstreetmap-importer-configuration-file.md).
 
-### Map Edition and Creation
+## Map Edition and Creation
 
 If you want to edit a map exported from OpenStreetMap before converting it into a Webots world, we recommend using JOSM.
 [JOSM](https://josm.openstreetmap.de) is an open source software written in Java.
@@ -113,7 +113,7 @@ Using JOSM you can easily edit a map in order to add some elements, correct some
 In addition to editing map from OpenStreetmap, JOSM is also very convenient to create new environment from scratch.
 You can see in the [previous picture](#left-the-osm-file-created-in-josm-right-the-resulting-world-open-in-webots-after-conversion) a map fully created in JOSM and then exported and opened in Webots.
 
-### Graphical User Interface
+## Graphical User Interface
 
 To ease the use of this tool, a graphical interace has been created.
 This grapical interface can easily be started from the last tab of the [robot window](robot-window.md).

--- a/automobile/sumo-exporter.md
+++ b/automobile/sumo-exporter.md
@@ -1,4 +1,4 @@
-## SUMO Exporter
+# SUMO Exporter
 
 In order to be able to simulate traffic in your simulation, it is required to have a SUMO network file (`sumo.net.xml`).
 The SUMO exporter can create SUMO network files from a Webots simulation.

--- a/automobile/sumo-interface.md
+++ b/automobile/sumo-interface.md
@@ -130,7 +130,7 @@ PROTO SumoDisplay [
 On the contrary, if the SUMO window is smaller than the resolution, the image will not entirely fill it.
 If `fitSize` is set to `TRUE`, the image will be automatically rescaled, in that case the width / height aspect ratio may not be respected depending on the SUMO window size.
 
-## Plugin Mechanism
+### Plugin Mechanism
 
 In addition to the PROTO parameters, the plugin mechanism can be used to extend the interface.
 The plugin should be written in python, be in the same folder as the SUMO network files, and should implement the `SumoSupervisorPlugin` class with the two following entry-point functions:
@@ -149,7 +149,7 @@ The second one is called at each SUMO step and the argument is the time step.
 
 Such a plugin can be used for example to change traffic light state in SUMO.
 
-## Using the SUMO Executables Distributed with Webots
+### Using the SUMO Executables Distributed with Webots
 
 SUMO is distributed with Webots, it is located in `WEBOTS_HOME/projects/default/resources/sumo`, you can find all the executables in the `bin` folder.
 To be able to use these executables you need first to add `WEBOTS_HOME/projects/default/resources/sumo/bin` to your PATH.

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -62,8 +62,6 @@ class TestReferences(unittest.TestCase):
                 anchors = self.anchors[md_path]
                 s = set()
                 for a in anchors:
-                    if 'html' in a:
-                        print a
                     if a in s:
                         self.assertTrue(
                             False,

--- a/tests/test_titles.py
+++ b/tests/test_titles.py
@@ -29,6 +29,14 @@ conjunctions = [
 ]
 
 
+def title_level(title):
+    """Returns the number of '#' to determine the title level."""
+    count = 0
+    while (title[count] == '#'):
+        count += 1
+    return count
+
+
 class TestTitles(unittest.TestCase):
     """Unit test of the titles."""
 
@@ -84,3 +92,14 @@ class TestTitles(unittest.TestCase):
                     self.assertTrue(lowercasePattern.match(word), msg='%s: word "%s" of title "%s" is not in lowercase.' % (t['md'], word, t['title']))
                 else:
                     self.assertTrue(uppercasePattern.match(word), msg='%s: word "%s" of title "%s" is not in uppercase.' % (t['md'], word, t['title']))
+
+    def test_first_heading_has_the_highest_level(self):
+        """Test that the first heading has the highest level."""
+        currentMD = ''
+        minLevel = 0
+        for t in self.titles:
+            if currentMD != t['md']:  # New MD file.
+                minLevel = title_level(t['title'])
+                currentMD = t['md']
+            else:
+                self.assertTrue(minLevel < title_level(t['title']), msg='%s: title "%s" has a level higher than or equals to the first heading level of this page.' % (t['md'], t['title']))


### PR DESCRIPTION
### Considerations:

- Having a main title per page is a strong and well adopted rule (only 3 pages are not respecting this, and it sounds like bugs).
- New index construction is based on this rule.

### TODO list

- [x] Add a test for this rule.
- [x] Fix the problematic pages.

### Preview

| Before (buggy index) | After |
| --- | --- |
| [openstreetmap-importer.md](https://www.cyberbotics.com/doc/automobile/openstreetmap-importer) | [openstreetmap-importer.m](https://www.cyberbotics.com/doc/automobile/openstreetmap-importer?version=fix-heandings) |
| [sumo-exporter.md](https://www.cyberbotics.com/doc/automobile/sumo-exporter) | [sumo-exporter.md](https://www.cyberbotics.com/doc/automobile/sumo-exporter?version=fix-heandings) |
| [sumo-interface.md](https://www.cyberbotics.com/doc/automobile/sumo-interface) | [sumo-interface.md](https://www.cyberbotics.com/doc/automobile/sumo-interface?version=fix-heandings) |