### PR TITLE
Improve API headers

### DIFF
--- a/automobile/car-library.md
+++ b/automobile/car-library.md
@@ -4,9 +4,10 @@ The [car](#car-library) library is supposed to be used together with the [driver
 It provides additional information and functions to which a normal human driver of a car does not have access (e.g., changing the blinking period of the indicator or getting the value of the wheels encoders).
 All the functions included in this library are explained below.
 
-**Name**
+### Car Library Functions
 
-**wbu\_car\_init**, **wbu\_car\_cleanup** - *Initialise and clean*
+#### `wbu_car_init`
+#### `wbu_car_cleanup`
 
 ```c
 #include <webots/car.h>
@@ -15,16 +16,17 @@ void wbu_car_init();
 void wbu_car_cleanup();
 ```
 
-**Description**
+##### Description
+
+*Initialise and clean*
 
 These two functions are respectively used to initialize and properly close the [car](#car-library) library (the first one should be called at the very beginning of the controller program and the second one at the very end).
 If you use the [driver](driver-library.md) library it is not needed to call these functions since they are already called from the corresponding functions of the [driver](driver-library.md) library.
 
 ---
 
-**Name**
-
-**wbu\_car\_get\_type**, **wbu\_car\_get\_engine\_type** - *Get the car and engine type*
+#### `wbu_car_get_type`
+#### `wbu_car_get_engine_type`
 
 ```c
 #include <webots/car.h>
@@ -33,7 +35,9 @@ wbu_car_type wbu_car_get_type();
 wbu_car_engine_type wbu_car_get_type();
 ```
 
-**Description**
+##### Description
+
+*Get the car and engine type*
 
 These two functions return respectively the type of transmission and of engine of the car.
 
@@ -60,9 +64,8 @@ These two functions return respectively the type of transmission and of engine o
 
 ---
 
-**Name**
-
-**wbu\_car\_set\_indicator\_period**, **wbu\_car\_get\_indicator\_period** - *Set and get the indicator period*
+#### `wbu_car_set_indicator_period`
+#### `wbu_car_get_indicator_period`
 
 ```c
 #include <webots/car.h>
@@ -71,7 +74,9 @@ void wbu_car_set_indicator_period(double period);
 double wbu_car_get_indicator_period();
 ```
 
-**Description**
+##### Description
+
+*Set and get the indicator period*
 
 The `wbu_car_set_indicator_period` function is used to change the blinking period of the indicators.
 The argument should be specified in seconds.
@@ -80,9 +85,8 @@ The `wbu_car_get_indicator_period` function returns the current blinking period 
 
 ---
 
-**Name**
-
-**wbu\_car\_get\_backwards\_lights**, **wbu\_car\_get\_brake\_lights** - *Get the state of the backwards/brake lights*
+#### `wbu_car_get_backwards_lights`
+#### `wbu_car_get_brake_lights`
 
 ```c
 #include <webots/car.h>
@@ -91,15 +95,19 @@ bool wbu_car_get_backwards_lights();
 bool wbu_car_get_brake_lights();
 ```
 
-**Description**
+##### Description
+
+*Get the state of the backwards/brake lights*
 
 These two functions return respectively the state of the backwards and brake lights (these two lights are switched on automatically by the library when appropriated).
 
 ---
 
-**Name**
-
-**wbu\_car\_get\_track\_front**, **wbu\_car\_get\_track\_rear**, **wbu\_car\_get\_wheelbase**, **wbu\_car\_get\_front\_wheel\_radius**, **wbu\_car\_get\_rear\_wheel\_radius** - *Get car caracteristics*
+#### `wbu_car_get_track_front`
+#### `wbu_car_get_track_rear`
+#### `wbu_car_get_wheelbase`
+#### `wbu_car_get_front_wheel_radius`
+#### `wbu_car_get_rear_wheel_radius`
 
 ```c
 #include <webots/car.h>
@@ -111,15 +119,16 @@ double wbu_car_get_front_wheel_radius();
 double wbu_car_get_rear_wheel_radius();
 ```
 
-**Description**
+##### Description
+
+*Get car caracteristics*
 
 All these functions provide important physical characteristics from the car.
 
 ---
 
-**Name**
-
-**wbu\_car\_get\_wheel\_encoder**, **wbu\_car\_get\_wheel\_speed** - *Get the wheels speed/encoder*
+#### `wbu_car_get_wheel_encoder`
+#### `wbu_car_get_wheel_speed`
 
 ```c
 #include <webots/car.h>
@@ -128,7 +137,9 @@ double wbu_car_get_wheel_encoder(int wheel_index);
 double wbu_car_get_wheel_speed(int wheel_index);
 ```
 
-**Description**
+##### Description
+
+*Get the wheels speed/encoder*
 
 These two functions return respectively the state of the wheel encoder (in radians) and the instantaneous wheel rotational speed (in radians per second).
 The `wheel_index` argument should match a value of the `wbu_car_wheel_index` enum.
@@ -147,9 +158,8 @@ The `wheel_index` argument should match a value of the `wbu_car_wheel_index` enu
 
 ---
 
-**Name**
-
-**wbu\_car\_get\_right\_steering\_angle**, **wbu\_car\_get\_left\_steering\_angle** - *Get the right/left steering angle*
+#### `wbu_car_get_right_steering_angle`
+#### `wbu_car_get_left_steering_angle`
 
 ```c
 #include <webots/car.h>
@@ -158,15 +168,15 @@ double wbu_car_get_right_steering_angle();
 double wbu_car_get_left_steering_angle();
 ```
 
-**Description**
+##### Description
+
+*Get the right/left steering angle*
 
 These two functions return respectively the right and left steering angles (because of the Ackermann steering geometry, the two angles are slightly different).
 
 ---
 
-**Name**
-
-**wbu\_car\_enable\_limited\_slip\_differential** - *Enable/disable the limited slip differential mechanism*
+#### `wbu_car_enable_limited_slip_differential`
 
 ```c
 #include <webots/car.h>
@@ -174,7 +184,9 @@ These two functions return respectively the right and left steering angles (beca
 void wbu_car_enable_limited_slip_differential(bool enable);
 ```
 
-**Description**
+##### Description
+
+*Enable/disable the limited slip differential mechanism*
 
 This function allows the user to enable or disable the limited differential slip (it is enabled by default).
 When the limited differential slip is enabled, at each time step, the torque (when control in torque is enabled) is redistributed amongst all the actuated wheels so that they rotate at the same speed (except the difference due to the geometric differential constraint).
@@ -182,9 +194,7 @@ If the limited differential slip is disabled, when a wheel starts to slip, it wi
 
 ---
 
-**Name**
-
-**wbu\_car\_enable\_indicator\_auto\_disabling** - *Enable/disable the auto-disabling mechanism of the indicator*
+#### `wbu_car_enable_indicator_auto_disabling`
 
 ```c
 #include <webots/car.h>
@@ -192,7 +202,9 @@ If the limited differential slip is disabled, when a wheel starts to slip, it wi
 void wbu_car_enable_indicator_auto_disabling(bool enable);
 ```
 
-**Description**
+##### Description
+
+*Enable/disable the auto-disabling mechanism of the indicator*
 
 This function allows the user to enable or disable the indicator auto-disabling mechanism (it is enabled by default).
 When indicator auto-disabling mechanism is enabled, the indicator is automatically switched off when the car starts steering in the inverse direction of the one indicated by the indicator.

--- a/automobile/car-library.md
+++ b/automobile/car-library.md
@@ -103,11 +103,11 @@ These two functions return respectively the state of the backwards and brake lig
 
 ---
 
-#### `wbu_car_get_track_front`
-#### `wbu_car_get_track_rear`
-#### `wbu_car_get_wheelbase`
-#### `wbu_car_get_front_wheel_radius`
-#### `wbu_car_get_rear_wheel_radius`
+#### `wbu_car_get_track_front`
+#### `wbu_car_get_track_rear`
+#### `wbu_car_get_wheelbase`
+#### `wbu_car_get_front_wheel_radius`
+#### `wbu_car_get_rear_wheel_radius`
 
 ```c
 #include <webots/car.h>

--- a/automobile/car-library.md
+++ b/automobile/car-library.md
@@ -176,7 +176,7 @@ These two functions return respectively the right and left steering angles (beca
 
 ---
 
-#### `wbu_car_enable_limited_slip_differential`
+#### `wbu_car_enable_limited_slip_differential`
 
 ```c
 #include <webots/car.h>

--- a/automobile/driver-library.md
+++ b/automobile/driver-library.md
@@ -3,9 +3,11 @@
 The [driver](#driver-library) library provides all the usual functionalities available to a human driving his own car.
 All the functions included in this library are explained below.
 
-**Name**
+### Driver Library Functions
 
-**wbu\_driver\_init**, **wbu\_driver\_cleanup**, **wbu\_driver\_step** - *Initialise, clean and run a driver step*
+#### `wbu_driver_init`
+#### `wbu_driver_cleanup`
+#### `wbu_driver_step`
 
 ```c
 #include <webots/driver.h>
@@ -15,7 +17,9 @@ void wbu_driver_cleanup();
 int wbu_driver_step();
 ```
 
-**Description**
+##### Description
+
+*Initialise, clean and run a driver step*
 
 These functions are the equivalent of the init, cleanup and step function of any regular robot controller.
 As a reminder, the `init` function should be called at the very beginning of any controller program, the `cleanup` function at the end of the controller program just before exiting and the `step` function should be called in the main loop to run one simulation step.
@@ -23,9 +27,8 @@ Unlike the robot step, the driver step does not have any argument, the default t
 
 ---
 
-**Name**
-
-**wbu\_driver\_set\_steering\_angle**, **wbu\_driver\_get\_steering\_angle** - *Set and get the stearing angle*
+#### `wbu_driver_set_steering_angle`
+#### `wbu_driver_get_steering_angle`
 
 ```c
 #include <webots/driver.h>
@@ -34,7 +37,9 @@ void wbu_driver_set_steering_angle(double steering_angle);
 double wbu_driver_get_steering_angle();
 ```
 
-**Description**
+##### Description
+
+*Set and get the stearing angle*
 
 The `wbu_driver_set_steering_angle` function is used to steer the car, it steers the front wheels according to the Ackermann geometry (left and right wheels are not steered with the exact same angle).
 The angle is set in radians, a positive angle steers right and a negative angle steers left.
@@ -49,9 +54,8 @@ The `wbu_driver_get_steering_angle` function returns the current steering angle.
 
 ---
 
-**Name**
-
-**wbu\_driver\_set\_cruising\_speed**, **wbu\_driver\_get\_target\_cruising\_speed** - *Set and get the target cruising speed*
+#### `wbu_driver_set_cruising_speed`
+#### `wbu_driver_get_target_cruising_speed`
 
 ```c
 #include <webots/driver.h>
@@ -60,7 +64,9 @@ void wbu_driver_set_cruising_speed(double speed);
 double wbu_driver_get_target_cruising_speed();
 ```
 
-**Description**
+##### Description
+
+*Set and get the target cruising speed*
 
 The `wbu_driver_set_cruising_speed` function activates the control in cruising speed of the car, the rotational speed of the wheels is forced (respecting the geometric differential constraint) in order for the car to move at the speed given in argument of the function (in kilometers per hour).
 When the control in cruising speed is activated, the speed is directly applied to the wheel without any engine model simulation, therefore any call to functions like `wbu_driver_get_rpm` will raise an error.
@@ -70,9 +76,7 @@ The `wbu_driver_get_target_cruising_speed` function simply returns the target cr
 
 ---
 
-**Name**
-
-**wbu\_driver\_get\_current\_speed** - *Get the current speed*
+#### `wbu_driver_get_current_speed`
 
 ```c
 #include <webots/driver.h>
@@ -80,16 +84,18 @@ The `wbu_driver_get_target_cruising_speed` function simply returns the target cr
 double wbu_driver_get_current_speed();
 ```
 
-**Description**
+##### Description
+
+*Get the current speed*
 
 This function returns the current speed of the car (in kilometers per hour).
 The estimated speed is computed using the rotational speed of the actuated wheels and their respective radius.
 
 ---
 
-**Name**
+#### `wbu_driver_set_throttle`
+#### `wbu_driver_get_throttle`
 
-**wbu\_driver\_set\_throttle**, **wbu\_driver\_get\_throttle** - *Set and get the throttle*
 
 ```c
 #include <webots/driver.h>
@@ -98,7 +104,9 @@ void wbu_driver_set_throttle(double throttle);
 double wbu_driver_get_throttle();
 ```
 
-**Description**
+##### Description
+
+*Set and get the throttle*
 
 The `wbu_driver_set_throttle` function is used in order to control the car in torque, it sets the state of the throttle.
 The argument should be between 0.0 and 1.0, 0 means that 0% of the output torque of the engine is sent to the wheels and 1.0 means that 100% of the output torque of the engine is sent to the wheels.
@@ -108,9 +116,8 @@ The `wbu_driver_get_throttle` function simply returns the state of the throttle 
 
 ---
 
-**Name**
-
-**wbu\_driver\_set\_brake\_intensity**, **wbu\_driver\_get\_brake\_intensity** - *Set and get the brake intensity*
+#### `wbu_driver_set_brake_intensity`
+#### `wbu_driver_get_brake_intensity`
 
 ```c
 #include <webots/driver.h>
@@ -119,7 +126,9 @@ void wbu_driver_set_brake_intensity(double intensity);
 double wbu_driver_get_brake_intensity();
 ```
 
-**Description**
+##### Description
+
+*Set and get the brake intensity*
 
 The `wbu_driver_set_brake_intensity` function brakes the car by increasing the `dampingConstant` coefficient of the rotational joints of each of the four wheels.
 The argument should be between 0.0 and 1.0, 0 means that no damping constant is added on the joints (no breaking), 1 means that the parameter `brakeCoefficient` of the [Car](car.md) PROTO is applied on the `dampingConstant` of each joint (the value will be linearly interpolated between 0 and `brakeCoefficient` for any arguments between 0 and 1).
@@ -128,9 +137,10 @@ The `wbu_driver_get_brake_intensity` function simply returns the current brake i
 
 ---
 
-**Name**
-
-**wbu\_driver\_set\_indicator**, **wbu\_driver\_get\_indicator**, **wbu\_driver\_set\_hazard\_flashers**, **wbu\_driver\_get\_hazard\_flashers** - *Set and get the indicator state*
+#### `wbu_driver_set_indicator`
+#### `wbu_driver_get_indicator`
+#### `wbu_driver_set_hazard_flashers`
+#### `wbu_driver_get_hazard_flashers`
 
 ```c
 #include <webots/driver.h>
@@ -141,7 +151,9 @@ void wbu_driver_set_hazard_flashers(bool state);
 bool wbu_driver_get_hazard_flashers();
 ```
 
-**Description**
+##### Description
+
+*Set and get the indicator state*
 
 The `wbu_driver_set_indicator` function allows the user to set (using the `wbu_indicator_state` enum) if the indicator should be on only for the right side of the car, the left side of the car or should be off.
 The `wbu_driver_get_indicator` function allows the user to get the indicator state.
@@ -161,9 +173,10 @@ The `wbu_driver_get_hazard_flashers` function allows the user to get the state o
 
 ---
 
-**Name**
-
-**wbu\_driver\_set\_dipped\_beams**, **wbu\_driver\_set\_antifog\_lights**, **wbu\_driver\_get\_dipped\_beams**, **wbu\_driver\_get\_antifog\_lights** - *Set and get the lights*
+#### `wbu_driver_set_dipped_beams`
+#### `wbu_driver_set_antifog_lights`
+#### `wbu_driver_get_dipped_beams`
+#### `wbu_driver_get_antifog_lights`
 
 ```c
 #include <webots/driver.h>
@@ -174,7 +187,9 @@ bool wbu_driver_get_dipped_beams();
 bool wbu_driver_get_antifog_lights();
 ```
 
-**Description**
+##### Description
+
+*Set and get the lights*
 
 The `wbu_driver_set_dipped_beams` and `wbu_driver_set_antifog_lights` functions are used to enable or disable the dipped beams and the anti-fog lights.
 
@@ -182,9 +197,7 @@ The `wbu_driver_get_dipped_beams` and `wbu_driver_get_antifog_lights` functions 
 
 ---
 
-**Name**
-
-**wbu\_driver\_get\_rpm** - *Get the motor rpm*
+#### `wbu_driver_get_rpm`
 
 ```c
 #include <webots/driver.h>
@@ -192,7 +205,9 @@ The `wbu_driver_get_dipped_beams` and `wbu_driver_get_antifog_lights` functions 
 double wbu_driver_get_rpm();
 ```
 
-**Description**
+##### Description
+
+*Get the motor rpm*
 
 This function returns the estimation of the engine rotation speed.
 
@@ -200,9 +215,9 @@ This function returns the estimation of the engine rotation speed.
 
 ---
 
-**Name**
-
-**wbu\_driver\_set\_gear**, **wbu\_driver\_get\_gear**, **wbu\_driver\_get\_gear\_number** - *Get and set the gear*
+#### `wbu_driver_set_gear`
+#### `wbu_driver_get_gear`
+#### `wbu_driver_get_gear_number`
 
 ```c
 #include <webots/driver.h>
@@ -212,7 +227,9 @@ int wbu_driver_get_gear();
 int wbu_driver_get_gear_number();
 ```
 
-**Description**
+##### Description
+
+*Get and set the gear*
 
 The `wbu_driver_set_gear` function sets the engaged gear.
 An argument of `-1` is used in order to engage the reverse gear, an argument of `0` is used in order to disengaged the gearbox.
@@ -224,9 +241,7 @@ The `wbu_driver_get_gear_number` function simply returns the number of available
 
 ---
 
-**Name**
-
-**wbu\_driver\_get\_control\_mode** - *Get the control mode*
+#### `wbu_driver_get_control_mode`
 
 ```c
 #include <webots/driver.h>
@@ -234,7 +249,9 @@ The `wbu_driver_get_gear_number` function simply returns the number of available
 wbu_control_mode wbu_driver_get_control_mode();
 ```
 
-**Description**
+##### Description
+
+*Get the control mode*
 
 This `wbu_driver_get_control_mode` returns the current control mode of the car.
 
@@ -249,9 +266,8 @@ This `wbu_driver_get_control_mode` returns the current control mode of the car.
 
 ---
 
-**Name**
-
-**wbu\_driver\_set\_wipers\_mode**, **wbu\_driver\_get\_wipers\_mode** - *Set and get the wipers' mode*
+#### `wbu_driver_set_wipers_mode`
+#### `wbu_driver_get_wipers_mode`
 
 ```c
 #include <webots/driver.h>
@@ -260,7 +276,9 @@ void wbu_driver_set_wipers_mode(int mode);
 wbu_wipers_mode wbu_driver_get_wipers_mode();
 ```
 
-**Description**
+##### Description
+
+*Set and get the wipers' mode*
 
 The `wbu_driver_set_wipers_mode` function allows the user to set (using the `wbu_wipers_mode` enum) various speeds for the wipers from slow to fast.
 Whilst the slow and normal mode share the same speed, the slow mode activates the wipers once every few seconds.

--- a/automobile/driver-library.md
+++ b/automobile/driver-library.md
@@ -93,7 +93,7 @@ The estimated speed is computed using the rotational speed of the actuated wheel
 
 ---
 
-#### `wbu_driver_set_throttle`
+#### `wbu_driver_set_throttle`
 #### `wbu_driver_get_throttle`
 
 
@@ -138,9 +138,9 @@ The `wbu_driver_get_brake_intensity` function simply returns the current brake i
 ---
 
 #### `wbu_driver_set_indicator`
-#### `wbu_driver_get_indicator`
-#### `wbu_driver_set_hazard_flashers`
-#### `wbu_driver_get_hazard_flashers`
+#### `wbu_driver_get_indicator`
+#### `wbu_driver_set_hazard_flashers`
+#### `wbu_driver_get_hazard_flashers`
 
 ```c
 #include <webots/driver.h>

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -322,6 +322,12 @@ body {
   font-family: "Roboto Mono", monospace;
   color: black;
 }
+.webots-doc .tag {
+  padding: 4px;
+  color: #036161;
+  margin: 5px;
+  background-color: #cfe2e0;
+}
 .webots-doc figcaption:hover .anchor-link,
 .webots-doc h1:hover .anchor-link,
 .webots-doc h2:hover .anchor-link,

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -294,11 +294,9 @@ body {
 }
 .webots-doc h5 {
   font-size: 16px;
-  margin: 0px 10px;
 }
 .webots-doc h6 {
   font-size: 14px;
-  margin: 0px 10px;
 }
 .webots-doc .release-tag {
   display: inline;
@@ -322,6 +320,7 @@ body {
   padding: 9px 0px;
 }
 .webots-doc .api-title {
+  margin: 0px 10px;
   padding: 0px;
   color: black;
   font-size: 15px;

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -318,13 +318,14 @@ body {
 }
 .webots-doc .api-title {
   padding: 0px;
-  margin: 0px 10px;
+  margin: 0px 0px 0px 10px;
   color: black;
   font-size: 15px;
   font-family: "Roboto Mono", monospace;
 }
 .webots-doc .tag-container {
   text-align: right;
+  margin-bottom: -3px
 }
 .webots-doc .tag {
   padding: 4px;

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -319,8 +319,9 @@ body {
 .webots-doc .api-title {
   padding: 0px;
   margin: 10px;
-  font-family: "Roboto Mono", monospace;
   color: black;
+  font-size: 15px;
+  font-family: "Roboto Mono", monospace;
 }
 .webots-doc .tag-container {
   text-align: right;

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -268,7 +268,8 @@ body {
 .webots-doc h1,
 .webots-doc h2,
 .webots-doc h3,
-.webots-doc h4 {
+.webots-doc h4,
+.webots-doc h5 {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: normal;
@@ -289,6 +290,10 @@ body {
 }
 .webots-doc h4 {
   font-size: 18px;
+}
+.webots-doc h5 {
+  font-size: 18px;
+  margin-left: 10px;
 }
 .webots-doc .release-tag {
   display: inline;
@@ -313,9 +318,8 @@ body {
 }
 .webots-doc .api-title {
   padding: 0px;
-  margin: 10px 0px;
+  margin: 10px;
   font-family: "Roboto Mono", monospace;
-  font-size: 16px;
   color: black;
 }
 .webots-doc figcaption:hover .anchor-link,

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -318,7 +318,7 @@ body {
 }
 .webots-doc .api-title {
   padding: 0px;
-  margin: 10px;
+  margin: 0px 10px;
   color: black;
   font-size: 15px;
   font-family: "Roboto Mono", monospace;

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -262,6 +262,9 @@ body {
 .webots-doc b, .webots-doc strong {
   color: #333;
 }
+.webots-doc hr {
+  margin: 40px 0px;
+}
 .webots-doc h1,
 .webots-doc h2,
 .webots-doc h3,
@@ -290,7 +293,7 @@ body {
 .webots-doc .release-tag {
   display: inline;
   font-size: 14px;
-  color: black;
+  color: #ccc;
 }
 .webots-doc .anchor-link-image {
   padding-left: 20px;
@@ -307,6 +310,13 @@ body {
   position: relative;
   left: -20px;
   padding: 9px 0px;
+}
+.webots-doc .api-title {
+  padding: 0px;
+  margin: 10px 0px;
+  font-family: "Roboto Mono", monospace;
+  font-size: 16px;
+  color: black;
 }
 .webots-doc figcaption:hover .anchor-link,
 .webots-doc h1:hover .anchor-link,

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -322,11 +322,21 @@ body {
   font-family: "Roboto Mono", monospace;
   color: black;
 }
+.webots-doc .tag-container {
+  text-align: right;
+}
 .webots-doc .tag {
   padding: 4px;
-  color: #036161;
-  margin: 5px;
-  background-color: #cfe2e0;
+  color: #ffffff;
+  padding: 6px 18px;
+  background-color: #006796;
+  margin: 2px;
+}
+.webots-doc .tag:hover {
+  color: white;
+  text-decoration: none;
+  outline: 0;
+  background: #489fca;
 }
 .webots-doc figcaption:hover .anchor-link,
 .webots-doc h1:hover .anchor-link,

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -269,7 +269,8 @@ body {
 .webots-doc h2,
 .webots-doc h3,
 .webots-doc h4,
-.webots-doc h5 {
+.webots-doc h5,
+.webots-doc h6 {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: normal;
@@ -292,8 +293,12 @@ body {
   font-size: 18px;
 }
 .webots-doc h5 {
-  font-size: 18px;
-  margin-left: 10px;
+  font-size: 16px;
+  margin: 0px 10px;
+}
+.webots-doc h6 {
+  font-size: 14px;
+  margin: 0px 10px;
 }
 .webots-doc .release-tag {
   display: inline;
@@ -318,7 +323,6 @@ body {
 }
 .webots-doc .api-title {
   padding: 0px;
-  margin: 0px 0px 0px 10px;
   color: black;
   font-size: 15px;
   font-family: "Roboto Mono", monospace;

--- a/css/webots-doc.css
+++ b/css/webots-doc.css
@@ -329,14 +329,14 @@ body {
   padding: 4px;
   color: #ffffff;
   padding: 6px 18px;
-  background-color: #006796;
+  background-color: #2f93c1;
   margin: 2px;
 }
 .webots-doc .tag:hover {
   color: white;
   text-decoration: none;
   outline: 0;
-  background: #489fca;
+  background: #70b6f5;
 }
 .webots-doc figcaption:hover .anchor-link,
 .webots-doc h1:hover .anchor-link,

--- a/guide/robotis-op2.md
+++ b/guide/robotis-op2.md
@@ -212,9 +212,7 @@ The other parameters are set to default values that are known to works fine.
 It is however possible to change them if needed, by changing the default values that are stored in a ".ini" configuration file.
 In the [appendix](#walking-parameters), all the parameters of the gait are explained.
 
-**Name**
-
-**RobotisOp2GaitManager(webots::Robot \*robot, const std::string &iniFilename)** - *Gait Manager constructor*
+##### `RobotisOp2GaitManager(webots::Robot *robot, const std::string &iniFilename)`
 
 ```cpp
 #include <RobotisOp2GaitManager.hpp>
@@ -222,7 +220,9 @@ In the [appendix](#walking-parameters), all the parameters of the gait are expla
 RobotisOp2GaitManager(webots::Robot *robot, const std::string &iniFilename);
 ```
 
-**Description**
+###### Description
+
+*Gait Manager constructor*
 
 The first parameter is the robot on which the algorithm applies and the second is the file name in which the default parameters are stored.
 
@@ -230,9 +230,11 @@ The following methods are available in order to modify the main parameters in yo
 
 ---
 
-**Name**
-
-**void setXAmplitude(double x)**, **void setYAmplitude(double y)**, **void setAAmplitude(double a)**, **void setMoveAimOn(bool q)**, **void setBalanceEnable(bool q)** - *Change the gait parameters*
+##### `void setXAmplitude(double x)`
+##### `void setYAmplitude(double y)`
+##### `void setAAmplitude(double a)`
+##### `void setMoveAimOn(bool q)`
+##### `void setBalanceEnable(bool q)`
 
 ```cpp
 #include <RobotisOp2GaitManager.hpp>
@@ -244,7 +246,9 @@ void setMoveAimOn(bool q);
 void setBalanceEnable(bool q);
 ```
 
-**Description**
+###### Description
+
+*Change the gait parameters*
 
 These are the open parameters, they have the following impact on the gait:
 
@@ -258,9 +262,9 @@ Finally the following methods can be used in order to run the algorithm:
 
 ---
 
-**Name**
-
-**void start()**, **void step(int duration)**, **void stop()** - *Start, stop and run the gait.*
+##### `void start()`
+##### `void step(int duration)`
+##### `void stop()`
 
 ```cpp
 #include <RobotisOp2GaitManager.hpp>
@@ -270,7 +274,9 @@ void step(int duration);
 int  stop();
 ```
 
-**Description**
+###### Description
+
+*Start, stop and run the gait.*
 
 The *start* and *stop* functions are used to start and stop the algorithm.
 The *step* function is used to run the algorithm for a specified *duration*, expressed in milliseconds.
@@ -279,7 +285,7 @@ The *step* function is used to run the algorithm for a specified *duration*, exp
 It is therefore essential to enable the `Gyro` device and the `PositionSensor` device of each motor before using it.
 If it is not the case, a warning will appear and they will automatically be enabled.
 
-### Motion Manager
+#### Motion Manager
 
 The `RobotisOp2MotionManager` class allows you to play a predefined motion stored in the "motion\_4096.bin" file.
 The main motions and their corresponding ids are listed in [appendix](#motions-files).
@@ -289,9 +295,7 @@ It is also possible to add custom motions to this file by using the `Action Edit
 > **Note**: The `Action Editor` tool is provided by ROBOTIS.
 More information about are available on the [website](http://support.robotis.com/en/product/darwin-op/development/tools/action_editor.htm).
 
-**Name**
-
-**RobotisOp2MotionManager(webots::Robot \*robot)** - *Motion Manager constructor*
+##### `RobotisOp2MotionManager(webots::Robot *robot)`
 
 ```cpp
 #include <RobotisOp2MotionManager.hpp>
@@ -299,15 +303,15 @@ More information about are available on the [website](http://support.robotis.com
 RobotisOp2MotionManager(webots::Robot *robot);
 ```
 
-**Description**
+###### Description
+
+*Motion Manager constructor*
 
 The first parameter is the robot on which the algorithm applies.
 
 ---
 
-**Name**
-
-**void playPage(int id)** - *Plays a motion*
+##### `void playPage(int id)`
 
 ```cpp
 #include <RobotisOp2MotionManager.hpp>
@@ -315,20 +319,22 @@ The first parameter is the robot on which the algorithm applies.
 void playPage(int id);
 ```
 
-**Description**
+###### Description
+
+*Plays a motion*
 
 Plays the motion associated with page `id`.
 
-#### Motion Manager in Step-by-Step
+##### Motion Manager in Step-by-Step
 
 By default when starting a motion, the motion is run synchronously.
 It means that the controller execution is stopped until the motion is finished.
 But it is also possible to run a motion asynchronously, in that case, the motion is started but the execution flow of the controller is not stopped.
 This can be done by calling the method `playPage` with the second parameter set to false:
 
-**Name**
-
-**void playPage(int id, bool sync = true)**, **void step(int duration)**, **bool isMotionPlaying()** - *Starts the motion in Step-by-Step mode.*
+##### `void playPage(int id, bool sync = true)`
+##### `void step(int duration)`
+##### `bool isMotionPlaying()`
 
 ```cpp
 #include <RobotisOp2MotionManager.hpp>
@@ -338,7 +344,9 @@ void step(int duration);
 bool isMotionPlaying();
 ```
 
-**Description**
+###### Description
+
+*Starts the motion in Step-by-Step mode.*
 
 The *playPage* function initializes the motion, but does not run it.
 The *step* method has to be called to run it (before calling the robot *step* function).
@@ -357,13 +365,11 @@ while (mMotionManager->isMotionPlaying()) {
 }
 ```
 
-### Vision Manager
+#### Vision Manager
 
 The `RobotisOp2VisionManager` class allows you to use some image processing tools.
 
-**Name**
-
-**RobotisOp2VisionManager(int width, int height, int hue, int hueTolerance, int minSaturation, int minValue, int minPercent, int maxPercent)** - *Vision Manager constructor*
+##### `RobotisOp2VisionManager(int width, int height, int hue, int hueTolerance, int minSaturation, int minValue, int minPercent, int maxPercent)`
 
 ```cpp
 #include <RobotisOp2VisionManager.hpp>
@@ -378,7 +384,9 @@ RobotisOp2VisionManager(int width,
                         int maxPercent);
 ```
 
-**Description**
+###### Description
+
+*Vision Manager constructor*
 
 The Vision Manager constructor.
 The arguments are the following:
@@ -403,9 +411,7 @@ To find the color hue of the target object and to understand the impact of the s
 
 ---
 
-**Name**
-
-**bool getBallCenter(double &x, double &y, const unsigned char \*image)** - *Get the position of the target object*
+##### `bool getBallCenter(double &x, double &y, const unsigned char \*image)`
 
 ```cpp
 #include <RobotisOp2VisionManager.hpp>
@@ -413,7 +419,9 @@ To find the color hue of the target object and to understand the impact of the s
 void getBallCenter(double &x, double &y, const unsigned char *image);
 ```
 
-**Description**
+###### Description
+
+*Get the position of the target object*
 
 Get the center of the target object.
 This method returns true if the target was found, and false otherwise.
@@ -429,9 +437,7 @@ This method proceeds with the following steps:
 
 ---
 
-**Name**
-
-**bool isDetected(int x, int y);** - *Determine if a pixel of the image is part of the target*
+##### `bool isDetected(int x, int y);`
 
 ```cpp
 #include <RobotisOp2VisionManager.hpp>
@@ -439,7 +445,9 @@ This method proceeds with the following steps:
 void isDetected(int x, int y);
 ```
 
-**Description**
+###### Description
+
+*Determine if a pixel of the image is part of the target*
 
 Once the method `getBallCenter` was called it is possible to know which pixels of the image are part of the target object by using the method `isDetected`.
 This method returns true if the pixel (x,y) is part of the target object and false otherwise.

--- a/js/showdown-extensions.js
+++ b/js/showdown-extensions.js
@@ -120,7 +120,7 @@ showdown.extension('wbAPI', function() {
     { // '#### `wb.*`' to h4 + "api-title" class
       type: 'lang',
       filter: function(text, converter, options) {
-        text = text.replace(/#### `(wb_[^ `\n]+?)`\n/gi, function(match, content) {
+        text = text.replace(/#### `(wb[urw]?_[^ `\n]+?)`\n/gi, function(match, content) {
           return '<h4 name="' + content + '" class="api-title">' + content + '</h4>';
         });
         return text;

--- a/js/showdown-extensions.js
+++ b/js/showdown-extensions.js
@@ -117,12 +117,16 @@ showdown.extension('wbAPI', function() {
         return text;
       }
     },
-    { // '\*\*wb.*\*\*' to anchor
+    { // '#### wb.*' to anchor
       type: 'lang',
       filter: function(text, converter, options) {
-        text = text.replace(/\*\*(wb\\_[^*]+?)\*\*/gi, function(match, content) {
+        text = text.replace(/#### (wb\\_[^\n]+?)\n/gi, function(match, content) {
           var protectedContent = content.replace(/\\_/g, '_');
-          return '<strong name="' + protectedContent + '">' + content + '</strong>';
+          var anchor = protectedContent;
+          var index = anchor.indexOf(',');
+          if (index > 0)
+            anchor = anchor.substring(0, index);
+          return '<h4 name="' + anchor + '">' + protectedContent + '</h4>';
         });
         return text;
       }

--- a/js/showdown-extensions.js
+++ b/js/showdown-extensions.js
@@ -117,11 +117,11 @@ showdown.extension('wbAPI', function() {
         return text;
       }
     },
-    { // '#### `wb.*`' to h4 + "api-title" class
+    { // '#### `.*`' to h[4|5] + "api-title" class
       type: 'lang',
       filter: function(text, converter, options) {
-        text = text.replace(/#### `(wb[urw]?_[^ `\n]+?)`\n/gi, function(match, content) {
-          return '<h4 name="' + content + '" class="api-title">' + content + '</h4>';
+        text = text.replace(/(#{4,5}) `([^`\n]+?)`\n/gi, function(match, hashes, content) {
+          return '<h' + hashes.length + ' name="' + content + '" class="api-title">' + content + '</h4>';
         });
         return text;
       }

--- a/js/showdown-extensions.js
+++ b/js/showdown-extensions.js
@@ -121,7 +121,7 @@ showdown.extension('wbAPI', function() {
       type: 'lang',
       filter: function(text, converter, options) {
         text = text.replace(/(#{4,5}) `([^`\n]+?)`\n/gi, function(match, hashes, content) {
-          return '<h' + hashes.length + ' name="' + content + '" class="api-title">' + content + '</h4>';
+          return '<h' + hashes.length + ' name="' + content + '" class="api-title">' + content + '</h' + hashes.length + '>';
         });
         return text;
       }

--- a/js/showdown-extensions.js
+++ b/js/showdown-extensions.js
@@ -13,7 +13,7 @@ function wbSlugify(obj) {
   return text
     .trim()
     .toLowerCase()
-    .replace(/[\s.]/g, '-')
+    .replace(/[\s.:]/g, '-')
     .replace(/[-]+/g, '-')
     .replace(/^-*/, '')
     .replace(/-*$/, '')
@@ -136,8 +136,8 @@ showdown.extension('wbAnchors', function() {
   return [
     {
       type: 'html',
-      regex: /<h(\d) id="([^]+?)">([^]+?)<\/h(\d)>/gi,
-      replace: function(match, level1, showdownId, content, level2) {
+      regex: /<h(\d)\s([^>]*)>([^]+?)<\/h(\d)>/gi,
+      replace: function(match, level1, args, content, level2) {
         if (level1 !== level2) {
           console.error('wbAnchors: level mismatch');
           return '';
@@ -147,7 +147,7 @@ showdown.extension('wbAnchors', function() {
         tmpDiv.innerHTML = content;
         var rawContent = tmpDiv.textContent || tmpDiv.innerText || '';
 
-        return '<h' + level1 + ' name="' + wbSlugify(rawContent) + '">' + content + '</h' + level1 + '>';
+        return '<h' + level1 + ' name="' + wbSlugify(rawContent) + '" ' + args + '>' + content + '</h' + level1 + '>';
       }
     }
   ];

--- a/js/showdown-extensions.js
+++ b/js/showdown-extensions.js
@@ -117,16 +117,11 @@ showdown.extension('wbAPI', function() {
         return text;
       }
     },
-    { // '#### wb.*' to anchor
+    { // '#### `wb.*`' to h4 + "api-title" class
       type: 'lang',
       filter: function(text, converter, options) {
-        text = text.replace(/#### (wb\\_[^\n]+?)\n/gi, function(match, content) {
-          var protectedContent = content.replace(/\\_/g, '_');
-          var anchor = protectedContent;
-          var index = anchor.indexOf(',');
-          if (index > 0)
-            anchor = anchor.substring(0, index);
-          return '<h4 name="' + anchor + '">' + protectedContent + '</h4>';
+        text = text.replace(/#### `(wb_[^ `\n]+?)`\n/gi, function(match, content) {
+          return '<h4 name="' + content + '" class="api-title">' + content + '</h4>';
         });
         return text;
       }

--- a/js/viewer.js
+++ b/js/viewer.js
@@ -832,8 +832,10 @@ function applyOOTags(view) {
   var as = view.querySelectorAll('a');
   for (var i = 0; i < as.length; i++) {
     var a = as[i];
-    if (['C++', 'Java', 'Python', 'ROS', 'Matlab'].includes(a.innerText))
+    if (['C++', 'Java', 'Python', 'ROS', 'Matlab'].includes(a.innerText)) {
       a.classList.add('tag');
+      a.parentNode.classList.add('tag-container');
+    }
   }
 }
 

--- a/js/viewer.js
+++ b/js/viewer.js
@@ -834,7 +834,8 @@ function applyOOTags(view) {
     var a = as[i];
     if (['C++', 'Java', 'Python', 'ROS', 'Matlab'].includes(a.innerText)) {
       a.classList.add('tag');
-      a.parentNode.classList.add('tag-container');
+      if (a.parentNode.tagName === 'p' && a.parentNode.classList.length === 0)
+        a.parentNode.classList.add('tag-container');
     }
   }
 }

--- a/js/viewer.js
+++ b/js/viewer.js
@@ -801,7 +801,7 @@ function renderGraphs() {
 
 function applyAnchorIcons(view) {
   var elements = [];
-  var tags = ['figcaption', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+  var tags = ['figcaption', 'h1', 'h2', 'h3', 'h4'];
   var i;
   for (i = 0; i < tags.length; i++) {
     var array = Array.prototype.slice.call(view.querySelectorAll(tags[i]));

--- a/js/viewer.js
+++ b/js/viewer.js
@@ -834,7 +834,7 @@ function applyOOTags(view) {
     var a = as[i];
     if (['C++', 'Java', 'Python', 'ROS', 'Matlab'].includes(a.innerText)) {
       a.classList.add('tag');
-      if (a.parentNode.tagName === 'p' && a.parentNode.classList.length === 0)
+      if (a.parentNode.tagName.toLowerCase() === 'p' && a.parentNode.classList.length === 0)
         a.parentNode.classList.add('tag-container');
     }
   }

--- a/js/viewer.js
+++ b/js/viewer.js
@@ -461,6 +461,7 @@ function populateViewDiv(mdContent) {
   collapseMovies(view);
 
   applyAnchorIcons(view);
+  applyOOTags(view);
   highlightCode(view);
 
   updateSelection();
@@ -824,6 +825,15 @@ function applyAnchorIcons(view) {
       a.appendChild(span);
       el.insertBefore(a, el.firstChild);
     }
+  }
+}
+
+function applyOOTags(view) {
+  var as = view.querySelectorAll('a');
+  for (var i = 0; i < as.length; i++) {
+    var a = as[i];
+    if (['C++', 'Java', 'Python', 'ROS', 'Matlab'].includes(a.innerText))
+      a.classList.add('tag');
   }
 }
 

--- a/reference/accelerometer.md
+++ b/reference/accelerometer.md
@@ -37,11 +37,12 @@ This field accepts any value in the interval (0.0, inf).
 
 ### Accelerometer Functions
 
-**Name**
+#### `wb_accelerometer_enable`
+#### `wb_accelerometer_disable`
+#### `wb_accelerometer_get_sampling_period`
+#### `wb_accelerometer_get_values`
 
-**wb\_accelerometer\_enable**, **wb\_accelerometer\_disable**, **wb\_accelerometer\_get\_sampling\_period**, **wb\_accelerometer\_get\_values** - *enable, disable and read the output of the accelerometer*
-
-{[C++](cpp-api.md#cpp_accelerometer)}, {[Java](java-api.md#java_accelerometer)}, {[Python](python-api.md#python_accelerometer)}, {[Matlab](matlab-api.md#matlab_accelerometer)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_accelerometer) [Java](java-api.md#java_accelerometer) [Python](python-api.md#python_accelerometer) [Matlab](matlab-api.md#matlab_accelerometer) [ROS](ros-api.md)
 
 ```c
 #include <webots/accelerometer.h>
@@ -52,7 +53,9 @@ int wb_accelerometer_get_sampling_period(WbDeviceTag tag)
 const double *wb_accelerometer_get_values(WbDeviceTag tag)
 ```
 
-**Description**
+##### Description
+
+*enable, disable and read the output of the accelerometer*
 
 The `wb_accelerometer_enable` function allows the user to enable the acceleration measurements.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.

--- a/reference/brake.md
+++ b/reference/brake.md
@@ -14,11 +14,10 @@ The [Brake](#brake) node can be inserted in the `device` field of a [HingeJoint]
 
 ### Brake Functions
 
-**Name**
+#### `wb_brake_set_damping_constant`
+#### `wb_brake_get_type`
 
-**wb\_brake\_set\_damping\_constant**, **wb\_brake\_get\_type** - *set the damping constant coefficient of the joint and get the type of brake*
-
-{[C++](cpp-api.md#cpp_brake)}, {[Java](java-api.md#java_brake)}, {[Python](python-api.md#python_brake)}, {[Matlab](matlab-api.md#matlab_brake)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_brake) [Java](java-api.md#java_brake) [Python](python-api.md#python_brake) [Matlab](matlab-api.md#matlab_brake) [ROS](ros-api.md)
 
 ```c
 #include <webots/brake.h>
@@ -27,7 +26,9 @@ void wb_brake_set_damping_constant(WbDeviceTag tag, double damping_constant);
 int wb_brake_get_type(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*set the damping constant coefficient of the joint and get the type of brake*
 
 The `wb_brake_set_damping_constant` function sets the value of the dampingConstant coefficient (Ns/m or Nms) of the joint.
 If any dampingConstant is already set using [JointParameters](jointparameters.md) the resulting dampingConstant coefficient is the sum of the one in the [JointParameters](jointparameters.md) and the one set using the `wb_brake_set_damping_constant` function.

--- a/reference/camera.md
+++ b/reference/camera.md
@@ -504,7 +504,7 @@ The `wb_camera_recognition_get_sampling_period` function returns the period give
 
 The `wb_camera_recognition_get_number_of_objects` and `wb_camera_recognition_get_objects` functions allow the user to get the current number of recognized objects and the objects array.
 
-### Camera recognition object
+### Camera Recognition Object
 
 A camera recognition object is defined by the following structure:
 

--- a/reference/camera.md
+++ b/reference/camera.md
@@ -200,11 +200,11 @@ void wb_camera_disable(WbDeviceTag tag);
 int wb_camera_get_sampling_period(WbDeviceTag tag);
 ```
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ##### Description
 
 *enable and disable camera updates*
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 The `wb_camera_enable` function allows the user to enable a camera.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.
@@ -230,11 +230,11 @@ double wb_camera_get_max_fov(WbDeviceTag tag);
 void wb_camera_set_fov(WbDeviceTag tag, double fov);
 ```
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ##### Description
 
 *get and set field of view for a camera*
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 These functions allow the controller to get and set the value for the field of view (fov) of a camera.
 The original value for this field of view is defined in the [Camera](#camera) node, as `fieldOfView`.
@@ -259,11 +259,11 @@ double wb_camera_get_min_focal_distance(WbDeviceTag tag);
 void wb_camera_set_focal_distance(WbDeviceTag tag, double focal_distance);
 ```
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ##### Description
 
 *get and set the focusing parmeters*
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 These functions allow the controller to get and set the focusing parameters.
 Note that if the camera device has no [Focus](focus.md) node defined in its `focus` field, it is not possible to call the `wb_camera_set_focal_distance` function and the other functions will return 0.
@@ -280,11 +280,11 @@ int wb_camera_get_width(WbDeviceTag tag);
 int wb_camera_get_height(WbDeviceTag tag);
 ```
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ##### Description
 
 *get the size of the camera image*
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 These functions return the width and height of a camera image as defined in the corresponding [Camera](#camera) node.
 
@@ -298,11 +298,11 @@ These functions return the width and height of a camera image as defined in the 
 double wb_camera_get_near(WbDeviceTag tag);
 ```
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ##### Description
 
 *get the near parameter of the camera device*
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 This function returns the near parameter of a camera device as defined in the corresponding [Camera](#camera) node.
 
@@ -324,11 +324,11 @@ unsigned char wb_camera_image_get_blue(const unsigned char *image, int width, in
 unsigned char wb_camera_image_get_gray(const unsigned char *image, int width, int x, int y);
 ```
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ##### Description
 
 *get the image data from a camera*
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 The `wb_camera_get_image` function reads the last image grabbed by the camera.
 The image is coded as a sequence of three bytes representing the red, green and blue levels of a pixel.
@@ -444,11 +444,11 @@ The dimensions of the array are the width and the length of camera's image and t
 int wb_camera_save_image(WbDeviceTag tag, const char *filename, int quality);
 ```
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ##### Description
 
 *save a camera image in either PNG or JPEG format*
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 The `wb_camera_save_image` function allows the user to save a `tag` image which was previously obtained with the `wb_camera_get_image` function.
 The image is saved in a file in either PNG or JPEG format.
@@ -485,11 +485,11 @@ int wb_camera_recognition_get_number_of_objects(WbDeviceTag tag);
 const WbCameraRecognitionObject *wb_camera_recognition_get_objects(WbDeviceTag tag);
 ```
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ##### Description
 
 *camera recognition functions*
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 If a [Recognition](recognition.md) node is present in the `recognition` field, the camera can recognize objects in its image.
 

--- a/reference/camera.md
+++ b/reference/camera.md
@@ -200,9 +200,11 @@ void wb_camera_disable(WbDeviceTag tag);
 int wb_camera_get_sampling_period(WbDeviceTag tag);
 ```
 
-**Description** *enable and disable camera updates*
+##### Description
 
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+*enable and disable camera updates*
+
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 The `wb_camera_enable` function allows the user to enable a camera.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.
@@ -228,9 +230,11 @@ double wb_camera_get_max_fov(WbDeviceTag tag);
 void wb_camera_set_fov(WbDeviceTag tag, double fov);
 ```
 
-**Description** *get and set field of view for a camera*
+##### Description
 
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+*get and set field of view for a camera*
+
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 These functions allow the controller to get and set the value for the field of view (fov) of a camera.
 The original value for this field of view is defined in the [Camera](#camera) node, as `fieldOfView`.
@@ -255,9 +259,11 @@ double wb_camera_get_min_focal_distance(WbDeviceTag tag);
 void wb_camera_set_focal_distance(WbDeviceTag tag, double focal_distance);
 ```
 
-**Description** *get and set the focusing parmaters*
+##### Description
 
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+*get and set the focusing parmeters*
+
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 These functions allow the controller to get and set the focusing parameters.
 Note that if the camera device has no [Focus](focus.md) node defined in its `focus` field, it is not possible to call the `wb_camera_set_focal_distance` function and the other functions will return 0.
@@ -274,9 +280,11 @@ int wb_camera_get_width(WbDeviceTag tag);
 int wb_camera_get_height(WbDeviceTag tag);
 ```
 
-**Description** *get the size of the camera image*
+##### Description
 
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+*get the size of the camera image*
+
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 These functions return the width and height of a camera image as defined in the corresponding [Camera](#camera) node.
 
@@ -290,9 +298,11 @@ These functions return the width and height of a camera image as defined in the 
 double wb_camera_get_near(WbDeviceTag tag);
 ```
 
-**Description** *get the near parameter of the camera device*
+##### Description
 
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+*get the near parameter of the camera device*
+
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 This function returns the near parameter of a camera device as defined in the corresponding [Camera](#camera) node.
 
@@ -314,9 +324,11 @@ unsigned char wb_camera_image_get_blue(const unsigned char *image, int width, in
 unsigned char wb_camera_image_get_gray(const unsigned char *image, int width, int x, int y);
 ```
 
-**Description** *get the image data from a camera*
+##### Description
 
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+*get the image data from a camera*
+
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 The `wb_camera_get_image` function reads the last image grabbed by the camera.
 The image is coded as a sequence of three bytes representing the red, green and blue levels of a pixel.
@@ -432,9 +444,11 @@ The dimensions of the array are the width and the length of camera's image and t
 int wb_camera_save_image(WbDeviceTag tag, const char *filename, int quality);
 ```
 
-**Description** *save a camera image in either PNG or JPEG format*
+##### Description
 
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+*save a camera image in either PNG or JPEG format*
+
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 The `wb_camera_save_image` function allows the user to save a `tag` image which was previously obtained with the `wb_camera_get_image` function.
 The image is saved in a file in either PNG or JPEG format.
@@ -471,9 +485,11 @@ int wb_camera_recognition_get_number_of_objects(WbDeviceTag tag);
 const WbCameraRecognitionObject *wb_camera_recognition_get_objects(WbDeviceTag tag);
 ```
 
-**Description** *camera recognition functions*
+##### Description
 
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+*camera recognition functions*
+
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 If a [Recognition](recognition.md) node is present in the `recognition` field, the camera can recognize objects in its image.
 

--- a/reference/camera.md
+++ b/reference/camera.md
@@ -192,6 +192,8 @@ Then, after closing the window, the overlay will be automatically restored.
 #### `wb_camera_disable`
 #### `wb_camera_get_sampling_period`
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ```c
 #include <webots/camera.h>
 
@@ -199,8 +201,6 @@ void wb_camera_enable(WbDeviceTag tag, int sampling_period);
 void wb_camera_disable(WbDeviceTag tag);
 int wb_camera_get_sampling_period(WbDeviceTag tag);
 ```
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ##### Description
 
@@ -221,6 +221,8 @@ The `wb_camera_get_sampling_period` function returns the period given to the `wb
 #### `wb_camera_get_max_fov`
 #### `wb_camera_set_fov`
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ```c
 #include <webots/camera.h>
 
@@ -229,8 +231,6 @@ double wb_camera_get_min_fov(WbDeviceTag tag);
 double wb_camera_get_max_fov(WbDeviceTag tag);
 void wb_camera_set_fov(WbDeviceTag tag, double fov);
 ```
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ##### Description
 
@@ -249,6 +249,8 @@ The minimum and maximum values for the field of view are defined in this [Zoom](
 #### `wb_camera_get_min_focal_distance`
 #### `wb_camera_set_focal_distance`
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ```c
 #include <webots/camera.h>
 
@@ -258,8 +260,6 @@ double wb_camera_get_max_focal_distance(WbDeviceTag tag);
 double wb_camera_get_min_focal_distance(WbDeviceTag tag);
 void wb_camera_set_focal_distance(WbDeviceTag tag, double focal_distance);
 ```
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ##### Description
 
@@ -273,14 +273,14 @@ Note that if the camera device has no [Focus](focus.md) node defined in its `foc
 #### `wb_camera_get_width`
 #### `wb_camera_get_height`
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ```c
 #include <webots/camera.h>
 
 int wb_camera_get_width(WbDeviceTag tag);
 int wb_camera_get_height(WbDeviceTag tag);
 ```
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ##### Description
 
@@ -292,13 +292,13 @@ These functions return the width and height of a camera image as defined in the 
 
 #### `wb_camera_get_near`
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ```c
 #include <webots/camera.h>
 
 double wb_camera_get_near(WbDeviceTag tag);
 ```
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ##### Description
 
@@ -314,6 +314,8 @@ This function returns the near parameter of a camera device as defined in the co
 #### `wb_camera_image_get_blue`
 #### `wb_camera_image_get_gray`
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ```c
 #include <webots/camera.h>
 
@@ -323,8 +325,6 @@ unsigned char wb_camera_image_get_green(const unsigned char *image, int width, i
 unsigned char wb_camera_image_get_blue(const unsigned char *image, int width, int x, int y);
 unsigned char wb_camera_image_get_gray(const unsigned char *image, int width, int x, int y);
 ```
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ##### Description
 
@@ -438,13 +438,13 @@ The dimensions of the array are the width and the length of camera's image and t
 
 #### `wb_camera_save_image`
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ```c
 #include <webots/camera.h>
 
 int wb_camera_save_image(WbDeviceTag tag, const char *filename, int quality);
 ```
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ##### Description
 
@@ -474,6 +474,8 @@ It is -1 in case of failure (unable to open the specified file or unrecognized i
 #### `wb_camera_recognition_get_number_of_objects`
 #### `wb_camera_recognition_get_objects`
 
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+
 ```c
 #include <webots/camera.h>
 
@@ -484,8 +486,6 @@ int wb_camera_recognition_get_sampling_period(WbDeviceTag tag);
 int wb_camera_recognition_get_number_of_objects(WbDeviceTag tag);
 const WbCameraRecognitionObject *wb_camera_recognition_get_objects(WbDeviceTag tag);
 ```
-
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ##### Description
 

--- a/reference/camera.md
+++ b/reference/camera.md
@@ -188,11 +188,9 @@ Then, after closing the window, the overlay will be automatically restored.
 
 ### Camera Functions
 
-#### wb\_camera\_enable, wb\_camera\_disable, wb\_camera\_get\_sampling\_period
-
-*enable and disable camera updates*
-
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+#### `wb_camera_enable`
+#### `wb_camera_disable`
+#### `wb_camera_get_sampling_period`
 
 ```c
 #include <webots/camera.h>
@@ -201,6 +199,10 @@ void wb_camera_enable(WbDeviceTag tag, int sampling_period);
 void wb_camera_disable(WbDeviceTag tag);
 int wb_camera_get_sampling_period(WbDeviceTag tag);
 ```
+
+**Description** *enable and disable camera updates*
+
+{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
 The `wb_camera_enable` function allows the user to enable a camera.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.
@@ -212,11 +214,10 @@ The `wb_camera_get_sampling_period` function returns the period given to the `wb
 
 ---
 
-#### wb\_camera\_get\_fov, wb\_camera\_get\_min\_fov, wb\_camera\_get\_max\_fov, wb\_camera\_set\_fov
-
-*get and set field of view for a camera*
-
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+#### `wb_camera_get_fov`
+#### `wb_camera_get_min_fov`
+#### `wb_camera_get_max_fov`
+#### `wb_camera_set_fov`
 
 ```c
 #include <webots/camera.h>
@@ -227,6 +228,10 @@ double wb_camera_get_max_fov(WbDeviceTag tag);
 void wb_camera_set_fov(WbDeviceTag tag, double fov);
 ```
 
+**Description** *get and set field of view for a camera*
+
+{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+
 These functions allow the controller to get and set the value for the field of view (fov) of a camera.
 The original value for this field of view is defined in the [Camera](#camera) node, as `fieldOfView`.
 Note that changing the field of view using the `wb_camera_set_fov` function is possible only if the camera device has a [Zoom](zoom.md) node defined in its `zoom` field.
@@ -234,11 +239,11 @@ The minimum and maximum values for the field of view are defined in this [Zoom](
 
 ---
 
-#### wb\_camera\_get\_focal\_length, wb\_camera\_get\_focal\_distance, wb\_camera\_get\_max\_focal\_distance, wb\_camera\_get\_min\_focal\_distance, wb\_camera\_set\_focal\_distance
-
-*get and set the focusing parmaters*
-
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+#### `wb_camera_get_focal_length`
+#### `wb_camera_get_focal_distance`
+#### `wb_camera_get_max_focal_distance`
+#### `wb_camera_get_min_focal_distance`
+#### `wb_camera_set_focal_distance`
 
 ```c
 #include <webots/camera.h>
@@ -250,16 +255,17 @@ double wb_camera_get_min_focal_distance(WbDeviceTag tag);
 void wb_camera_set_focal_distance(WbDeviceTag tag, double focal_distance);
 ```
 
+**Description** *get and set the focusing parmaters*
+
+{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+
 These functions allow the controller to get and set the focusing parameters.
 Note that if the camera device has no [Focus](focus.md) node defined in its `focus` field, it is not possible to call the `wb_camera_set_focal_distance` function and the other functions will return 0.
 
 ---
 
-#### wb\_camera\_get\_width, wb\_camera\_get\_height
-
-*get the size of the camera image*
-
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+#### `wb_camera_get_width`
+#### `wb_camera_get_height`
 
 ```c
 #include <webots/camera.h>
@@ -268,15 +274,15 @@ int wb_camera_get_width(WbDeviceTag tag);
 int wb_camera_get_height(WbDeviceTag tag);
 ```
 
+**Description** *get the size of the camera image*
+
+{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+
 These functions return the width and height of a camera image as defined in the corresponding [Camera](#camera) node.
 
 ---
 
-#### wb\_camera\_get\_near
-
-*get the near parameter of the camera device*
-
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+#### `wb_camera_get_near`
 
 ```c
 #include <webots/camera.h>
@@ -284,15 +290,19 @@ These functions return the width and height of a camera image as defined in the 
 double wb_camera_get_near(WbDeviceTag tag);
 ```
 
+**Description** *get the near parameter of the camera device*
+
+{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+
 This function returns the near parameter of a camera device as defined in the corresponding [Camera](#camera) node.
 
 ---
 
-#### wb\_camera\_get\_image, wb\_camera\_image\_get\_red, wb\_camera\_image\_get\_green, wb\_camera\_image\_get\_blue, wb\_camera\_image\_get\_gray
-
-*get the image data from a camera*
-
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+#### `wb_camera_get_image`
+#### `wb_camera_image_get_red`
+#### `wb_camera_image_get_green`
+#### `wb_camera_image_get_blue`
+#### `wb_camera_image_get_gray`
 
 ```c
 #include <webots/camera.h>
@@ -303,6 +313,10 @@ unsigned char wb_camera_image_get_green(const unsigned char *image, int width, i
 unsigned char wb_camera_image_get_blue(const unsigned char *image, int width, int x, int y);
 unsigned char wb_camera_image_get_gray(const unsigned char *image, int width, int x, int y);
 ```
+
+**Description** *get the image data from a camera*
+
+{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
 The `wb_camera_get_image` function reads the last image grabbed by the camera.
 The image is coded as a sequence of three bytes representing the red, green and blue levels of a pixel.
@@ -410,17 +424,17 @@ The dimensions of the array are the width and the length of camera's image and t
 
 ---
 
-#### wb\_camera\_save\_image
-
-*save a camera image in either PNG or JPEG format*
-
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+#### `wb_camera_save_image`
 
 ```c
 #include <webots/camera.h>
 
 int wb_camera_save_image(WbDeviceTag tag, const char *filename, int quality);
 ```
+
+**Description** *save a camera image in either PNG or JPEG format*
+
+{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
 The `wb_camera_save_image` function allows the user to save a `tag` image which was previously obtained with the `wb_camera_get_image` function.
 The image is saved in a file in either PNG or JPEG format.
@@ -439,11 +453,12 @@ It is -1 in case of failure (unable to open the specified file or unrecognized i
 
 ---
 
-#### wb\_camera\_has\_recognition, wb\_camera\_recognition\_enable, wb\_camera\_recognition\_disable, wb\_camera\_recognition\_get\_sampling\_period, wb\_camera\_recognition\_get\_number\_of\_objects, wb\_camera\_recognition\_get\_objects
-
-*camera recognition functions*
-
-{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
+#### `wb_camera_has_recognition`
+#### `wb_camera_recognition_enable`
+#### `wb_camera_recognition_disable`
+#### `wb_camera_recognition_get_sampling_period`
+#### `wb_camera_recognition_get_number_of_objects`
+#### `wb_camera_recognition_get_objects`
 
 ```c
 #include <webots/camera.h>
@@ -455,6 +470,10 @@ int wb_camera_recognition_get_sampling_period(WbDeviceTag tag);
 int wb_camera_recognition_get_number_of_objects(WbDeviceTag tag);
 const WbCameraRecognitionObject *wb_camera_recognition_get_objects(WbDeviceTag tag);
 ```
+
+**Description** *camera recognition functions*
+
+{[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
 If a [Recognition](recognition.md) node is present in the `recognition` field, the camera can recognize objects in its image.
 

--- a/reference/camera.md
+++ b/reference/camera.md
@@ -188,9 +188,9 @@ Then, after closing the window, the overlay will be automatically restored.
 
 ### Camera Functions
 
-**Name**
+#### wb\_camera\_enable, wb\_camera\_disable, wb\_camera\_get\_sampling\_period
 
-**wb\_camera\_enable**, **wb\_camera\_disable**, **wb\_camera\_get\_sampling\_period** - *enable and disable camera updates*
+*enable and disable camera updates*
 
 {[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
@@ -202,8 +202,6 @@ void wb_camera_disable(WbDeviceTag tag);
 int wb_camera_get_sampling_period(WbDeviceTag tag);
 ```
 
-**Description**
-
 The `wb_camera_enable` function allows the user to enable a camera.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.
 Note that the first measurement will be available only after the first sampling period elapsed.
@@ -214,9 +212,9 @@ The `wb_camera_get_sampling_period` function returns the period given to the `wb
 
 ---
 
-**Name**
+#### wb\_camera\_get\_fov, wb\_camera\_get\_min\_fov, wb\_camera\_get\_max\_fov, wb\_camera\_set\_fov
 
-**wb\_camera\_get\_fov**, **wb\_camera\_get\_min\_fov**, **wb\_camera\_get\_max\_fov**, **wb\_camera\_set\_fov** - *get and set field of view for a camera*
+*get and set field of view for a camera*
 
 {[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
@@ -229,8 +227,6 @@ double wb_camera_get_max_fov(WbDeviceTag tag);
 void wb_camera_set_fov(WbDeviceTag tag, double fov);
 ```
 
-**Description**
-
 These functions allow the controller to get and set the value for the field of view (fov) of a camera.
 The original value for this field of view is defined in the [Camera](#camera) node, as `fieldOfView`.
 Note that changing the field of view using the `wb_camera_set_fov` function is possible only if the camera device has a [Zoom](zoom.md) node defined in its `zoom` field.
@@ -238,9 +234,9 @@ The minimum and maximum values for the field of view are defined in this [Zoom](
 
 ---
 
-**Name**
+#### wb\_camera\_get\_focal\_length, wb\_camera\_get\_focal\_distance, wb\_camera\_get\_max\_focal\_distance, wb\_camera\_get\_min\_focal\_distance, wb\_camera\_set\_focal\_distance
 
-**wb\_camera\_get\_focal\_length**, **wb\_camera\_get\_focal\_distance**, **wb\_camera\_get\_max\_focal\_distance**, **wb\_camera\_get\_min\_focal\_distance**, **wb\_camera\_set\_focal\_distance** - *get and set the focusing parmaters*
+*get and set the focusing parmaters*
 
 {[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
@@ -254,16 +250,14 @@ double wb_camera_get_min_focal_distance(WbDeviceTag tag);
 void wb_camera_set_focal_distance(WbDeviceTag tag, double focal_distance);
 ```
 
-**Description**
-
 These functions allow the controller to get and set the focusing parameters.
 Note that if the camera device has no [Focus](focus.md) node defined in its `focus` field, it is not possible to call the `wb_camera_set_focal_distance` function and the other functions will return 0.
 
 ---
 
-**Name**
+#### wb\_camera\_get\_width, wb\_camera\_get\_height
 
-**wb\_camera\_get\_width**, **wb\_camera\_get\_height** - *get the size of the camera image*
+*get the size of the camera image*
 
 {[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
@@ -274,15 +268,13 @@ int wb_camera_get_width(WbDeviceTag tag);
 int wb_camera_get_height(WbDeviceTag tag);
 ```
 
-**Description**
-
 These functions return the width and height of a camera image as defined in the corresponding [Camera](#camera) node.
 
 ---
 
-**Name**
+#### wb\_camera\_get\_near
 
-**wb\_camera\_get\_near** - *get the near parameter of the camera device*
+*get the near parameter of the camera device*
 
 {[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
@@ -292,15 +284,13 @@ These functions return the width and height of a camera image as defined in the 
 double wb_camera_get_near(WbDeviceTag tag);
 ```
 
-**Description**
-
 This function returns the near parameter of a camera device as defined in the corresponding [Camera](#camera) node.
 
 ---
 
-**Name**
+#### wb\_camera\_get\_image, wb\_camera\_image\_get\_red, wb\_camera\_image\_get\_green, wb\_camera\_image\_get\_blue, wb\_camera\_image\_get\_gray
 
-**wb\_camera\_get\_image**, **wb\_camera\_image\_get\_red**, **wb\_camera\_image\_get\_green**, **wb\_camera\_image\_get\_blue**, **wb\_camera\_image\_get\_gray** - *get the image data from a camera*
+*get the image data from a camera*
 
 {[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
@@ -313,8 +303,6 @@ unsigned char wb_camera_image_get_green(const unsigned char *image, int width, i
 unsigned char wb_camera_image_get_blue(const unsigned char *image, int width, int x, int y);
 unsigned char wb_camera_image_get_gray(const unsigned char *image, int width, int x, int y);
 ```
-
-**Description**
 
 The `wb_camera_get_image` function reads the last image grabbed by the camera.
 The image is coded as a sequence of three bytes representing the red, green and blue levels of a pixel.
@@ -422,9 +410,9 @@ The dimensions of the array are the width and the length of camera's image and t
 
 ---
 
-**Name**
+#### wb\_camera\_save\_image
 
-**wb\_camera\_save\_image** - *save a camera image in either PNG or JPEG format*
+*save a camera image in either PNG or JPEG format*
 
 {[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
@@ -433,8 +421,6 @@ The dimensions of the array are the width and the length of camera's image and t
 
 int wb_camera_save_image(WbDeviceTag tag, const char *filename, int quality);
 ```
-
-**Description**
 
 The `wb_camera_save_image` function allows the user to save a `tag` image which was previously obtained with the `wb_camera_get_image` function.
 The image is saved in a file in either PNG or JPEG format.
@@ -453,9 +439,9 @@ It is -1 in case of failure (unable to open the specified file or unrecognized i
 
 ---
 
-**Name**
+#### wb\_camera\_has\_recognition, wb\_camera\_recognition\_enable, wb\_camera\_recognition\_disable, wb\_camera\_recognition\_get\_sampling\_period, wb\_camera\_recognition\_get\_number\_of\_objects, wb\_camera\_recognition\_get\_objects
 
-**wb\_camera\_has\_recognition**, **wb\_camera\_recognition\_enable**, **wb\_camera\_recognition\_disable**, **wb\_camera\_recognition\_get\_sampling\_period**, **wb\_camera\_recognition\_get\_number\_of\_objects**, **wb\_camera\_recognition\_get\_objects** - *camera recognition functions*
+*camera recognition functions*
 
 {[C++](cpp-api.md#cpp_camera)}, {[Java](java-api.md#java_camera)}, {[Python](python-api.md#python_camera)}, {[Matlab](matlab-api.md#matlab_camera)}, {[ROS](ros-api.md)}
 
@@ -470,8 +456,6 @@ int wb_camera_recognition_get_number_of_objects(WbDeviceTag tag);
 const WbCameraRecognitionObject *wb_camera_recognition_get_objects(WbDeviceTag tag);
 ```
 
-**Description**
-
 If a [Recognition](recognition.md) node is present in the `recognition` field, the camera can recognize objects in its image.
 
 The `wb_camera_has_recognition` function can be used to determine whether a [Recognition](recognition.md) node is present or not.
@@ -485,9 +469,7 @@ The `wb_camera_recognition_get_sampling_period` function returns the period give
 
 The `wb_camera_recognition_get_number_of_objects` and `wb_camera_recognition_get_objects` functions allow the user to get the current number of recognized objects and the objects array.
 
----
-
-**Camera recognition object**
+### Camera recognition object
 
 A camera recognition object is defined by the following structure:
 

--- a/reference/compass.md
+++ b/reference/compass.md
@@ -36,9 +36,10 @@ This field accepts any value in the interval (0.0, inf).
 
 ### Compass Functions
 
-**Name**
-
-**wb\_compass\_enable**, **wb\_compass\_disable**, **wb\_compass\_get\_sampling\_period**, **wb\_compass\_get\_values** - *enable, disable and read the output values of the compass device*
+#### `wb_compass_enable`
+#### `wb_compass_disable`
+#### `wb_compass_get_sampling_period`
+#### `wb_compass_get_values`
 
 [C++](cpp-api.md#cpp_compass) [Java](java-api.md#java_compass) [Python](python-api.md#python_compass) [Matlab](matlab-api.md#matlab_compass) [ROS](ros-api.md)
 
@@ -51,7 +52,9 @@ const double *wb_compass_get_values(WbDeviceTag tag);
 int wb_compass_get_sampling_period(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable, disable and read the output values of the compass device*
 
 The `wb_compass_enable` function turns on the [Compass](#compass) measurements.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.

--- a/reference/compass.md
+++ b/reference/compass.md
@@ -40,7 +40,7 @@ This field accepts any value in the interval (0.0, inf).
 
 **wb\_compass\_enable**, **wb\_compass\_disable**, **wb\_compass\_get\_sampling\_period**, **wb\_compass\_get\_values** - *enable, disable and read the output values of the compass device*
 
-{[C++](cpp-api.md#cpp_compass)}, {[Java](java-api.md#java_compass)}, {[Python](python-api.md#python_compass)}, {[Matlab](matlab-api.md#matlab_compass)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_compass) [Java](java-api.md#java_compass) [Python](python-api.md#python_compass) [Matlab](matlab-api.md#matlab_compass) [ROS](ros-api.md)
 
 ```c
 #include <webots/compass.h>

--- a/reference/connector.md
+++ b/reference/connector.md
@@ -139,9 +139,10 @@ But it is not necessary to add a [Physics](physics.md) node to the [Connector](#
 
 ### Connector Functions
 
-**Name**
-
-**wb\_connector\_enable\_presence**, **wb\_connector\_disable\_presence**, **wb\_connector\_get\_presence\_sampling\_period**, **wb\_connector\_get\_presence** - *detect the presence of another connector*
+#### `wb_connector_enable_presence`
+#### `wb_connector_disable_presence`
+#### `wb_connector_get_presence_sampling_period`
+#### `wb_connector_get_presence`
 
 [C++](cpp-api.md#cpp_connector) [Java](java-api.md#java_connector) [Python](python-api.md#python_connector) [Matlab](matlab-api.md#matlab_connector) [ROS](ros-api.md)
 
@@ -154,7 +155,9 @@ int wb_connector_get_presence_sampling_period(WbDeviceTag tag);
 int wb_connector_get_presence(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*detect the presence of another connector*
 
 The `wb_connector_enable_presence` function starts querying the presence sensor of the [Connector](#connector).
 The `sampling_period` argument specifies the sampling period of the presence sensor.
@@ -195,9 +198,8 @@ rotation_aligned := the n-ways rotational angle is within tolerance
 
 ---
 
-**Name**
-
-**wb\_connector\_lock**, **wb\_connector\_unlock** - *create / destroy the physical connection between two connector nodes*
+#### `wb_connector_lock`
+#### `wb_connector_unlock`
 
 [C++](cpp-api.md#cpp_connector) [Java](java-api.md#java_connector) [Python](python-api.md#python_connector) [Matlab](matlab-api.md#matlab_connector) [ROS](ros-api.md)
 
@@ -208,7 +210,9 @@ void wb_connector_lock(WbDeviceTag tag);
 void wb_connector_unlock(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*create / destroy the physical connection between two connector nodes*
 
 The `wb_connector_lock` and `wb_connector_unlock` functions can be used to set or unset the [Connector](#connector)'s locking state (`isLocked` field) and eventually create or destroy the physical connection between two [Connector](#connector) nodes.
 

--- a/reference/connector.md
+++ b/reference/connector.md
@@ -143,7 +143,7 @@ But it is not necessary to add a [Physics](physics.md) node to the [Connector](#
 
 **wb\_connector\_enable\_presence**, **wb\_connector\_disable\_presence**, **wb\_connector\_get\_presence\_sampling\_period**, **wb\_connector\_get\_presence** - *detect the presence of another connector*
 
-{[C++](cpp-api.md#cpp_connector)}, {[Java](java-api.md#java_connector)}, {[Python](python-api.md#python_connector)}, {[Matlab](matlab-api.md#matlab_connector)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_connector) [Java](java-api.md#java_connector) [Python](python-api.md#python_connector) [Matlab](matlab-api.md#matlab_connector) [ROS](ros-api.md)
 
 ```c
 #include <webots/connector.h>
@@ -199,7 +199,7 @@ rotation_aligned := the n-ways rotational angle is within tolerance
 
 **wb\_connector\_lock**, **wb\_connector\_unlock** - *create / destroy the physical connection between two connector nodes*
 
-{[C++](cpp-api.md#cpp_connector)}, {[Java](java-api.md#java_connector)}, {[Python](python-api.md#python_connector)}, {[Matlab](matlab-api.md#matlab_connector)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_connector) [Java](java-api.md#java_connector) [Python](python-api.md#python_connector) [Matlab](matlab-api.md#matlab_connector) [ROS](ros-api.md)
 
 ```c
 #include <webots/connector.h>

--- a/reference/device.md
+++ b/reference/device.md
@@ -17,7 +17,7 @@ This abstract node (not instanciable) represents a robot device (actuator and/or
 
 **wb\_device\_get\_model** - *returns the model string of the corresponding device*
 
-{[C++](cpp-api.md#cpp_device)}, {[Java](java-api.md#java_device)}, {[Python](python-api.md#python_device)}, {[Matlab](matlab-api.md#matlab_device)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [Matlab](matlab-api.md#matlab_device) [ROS](ros-api.md)
 
 ```c
 #include <webots/device.h>
@@ -37,7 +37,7 @@ This function returns NULL if the WbDeviceTag does not match a valid device, or 
 
 **wb\_device\_get\_name** - *convert WbDeviceTag to its corresponding device name*
 
-{[C++](cpp-api.md#cpp_device)}, {[Java](java-api.md#java_device)}, {[Python](python-api.md#python_device)}, {[Matlab](matlab-api.md#matlab_device)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [Matlab](matlab-api.md#matlab_device) [ROS](ros-api.md)
 
 ```c
 #include <webots/device.h>
@@ -57,7 +57,7 @@ This function returns NULL if the WbDeviceTag does not match a valid device.
 
 **wb\_device\_get\_node\_type** - *convert WbDeviceTag to its corresponding WbNodeType*
 
-{[C++](cpp-api.md#cpp_device)}, {[Java](java-api.md#java_device)}, {[Python](python-api.md#python_device)}, {[Matlab](matlab-api.md#matlab_device)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [Matlab](matlab-api.md#matlab_device) [ROS](ros-api.md)
 
 ```c
 #include <webots/device.h>

--- a/reference/device.md
+++ b/reference/device.md
@@ -13,9 +13,7 @@ This abstract node (not instanciable) represents a robot device (actuator and/or
 
 ### Device Functions
 
-**Name**
-
-**wb\_device\_get\_model** - *returns the model string of the corresponding device*
+#### `wb_device_get_model`
 
 [C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [Matlab](matlab-api.md#matlab_device) [ROS](ros-api.md)
 
@@ -25,7 +23,9 @@ This abstract node (not instanciable) represents a robot device (actuator and/or
 const char *wb_device_get_model(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*returns the model string of the corresponding device*
 
 The `wb_device_get_model` function returns the model string of the device corresponding to the WbDeviceTag given as parameter (`tag`).
 
@@ -33,9 +33,7 @@ This function returns NULL if the WbDeviceTag does not match a valid device, or 
 
 ---
 
-**Name**
-
-**wb\_device\_get\_name** - *convert WbDeviceTag to its corresponding device name*
+#### `wb_device_get_name`
 
 [C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [Matlab](matlab-api.md#matlab_device) [ROS](ros-api.md)
 
@@ -45,7 +43,9 @@ This function returns NULL if the WbDeviceTag does not match a valid device, or 
 const char *wb_device_get_name(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*convert WbDeviceTag to its corresponding device name*
 
 The `wb_device_get_name` function converts the WbDeviceTag given as parameter (`tag`) to its corresponding name.
 
@@ -53,9 +53,7 @@ This function returns NULL if the WbDeviceTag does not match a valid device.
 
 ---
 
-**Name**
-
-**wb\_device\_get\_node\_type** - *convert WbDeviceTag to its corresponding WbNodeType*
+#### `wb_device_get_node_type`
 
 [C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [Matlab](matlab-api.md#matlab_device) [ROS](ros-api.md)
 
@@ -65,7 +63,9 @@ This function returns NULL if the WbDeviceTag does not match a valid device.
 WbNodeType wb_device_get_node_type(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*convert WbDeviceTag to its corresponding WbNodeType*
 
 The `wb_device_get_node_type` function converts the WbDeviceTag given as parameter (`tag`) to its corresponding WbNodeType (cf. the [Supervisor](supervisor.md) API).
 

--- a/reference/differentialwheels.md
+++ b/reference/differentialwheels.md
@@ -128,7 +128,7 @@ Unlike the "physics" mode, in the "kinematics" mode the gravity and other forces
 
 **wb\_differential\_wheels\_set\_speed** - *control the speed of the robot*
 
-{[C++](cpp-api.md#cpp_differential_wheels)}, {[Java](java-api.md#java_differential_wheels)}, {[Python](python-api.md#python_differential_wheels)}, {[Matlab](matlab-api.md#matlab_differential_wheels)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
 ```c
 #include <webots/differential_wheels.h>
@@ -156,7 +156,7 @@ The `wb_differential_wheels_get_left_speed` and `wb_differential_wheels_get_righ
 
 **wb\_differential\_wheels\_enable\_encoders**, **wb\_differential\_wheels\_disable\_encoders**, **wb\_differential\_wheels\_get\_encoders\_sampling\_period** - *enable or disable the incremental encoders of the robot wheels*
 
-{[C++](cpp-api.md#cpp_differential_wheels)}, {[Java](java-api.md#java_differential_wheels)}, {[Python](python-api.md#python_differential_wheels)}, {[Matlab](matlab-api.md#matlab_differential_wheels)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
 ```c
 #include <webots/differential_wheels.h>
@@ -187,7 +187,7 @@ Note that the first encoders values will be available only after the first sampl
 
 **wb\_differential\_wheels\_get\_left\_encoder**, **wb\_differential\_wheels\_get\_right\_encoder**, **wb\_differential\_wheels\_set\_encoders** - *read or set the encoders of the robot wheels*
 
-{[C++](cpp-api.md#cpp_differential_wheels)}, {[Java](java-api.md#java_differential_wheels)}, {[Python](python-api.md#python_differential_wheels)}, {[Matlab](matlab-api.md#matlab_differential_wheels)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
 ```c
 #include <webots/differential_wheels.h>
@@ -210,7 +210,7 @@ Setting the encoders' values will not make the wheels rotate to reach the specif
 
 **wb\_differential\_wheels\_get\_max\_speed** - *get the value of the maxSpeed field*
 
-{[C++](cpp-api.md#cpp_differential_wheels)}, {[Java](java-api.md#java_differential_wheels)}, {[Python](python-api.md#python_differential_wheels)}, {[Matlab](matlab-api.md#matlab_differential_wheels)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
 ```c
 #include <webots/differential_wheels.h>
@@ -228,7 +228,7 @@ The `wb_differential_wheels_get_max_speed` function allows the user to get the v
 
 **wb\_differential\_wheels\_get\_speed\_unit** - *get the value of the speedUnit field*
 
-{[C++](cpp-api.md#cpp_differential_wheels)}, {[Java](java-api.md#java_differential_wheels)}, {[Python](python-api.md#python_differential_wheels)}, {[Matlab](matlab-api.md#matlab_differential_wheels)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
 ```c
 #include <webots/differential_wheels.h>

--- a/reference/differentialwheels.md
+++ b/reference/differentialwheels.md
@@ -124,9 +124,7 @@ Unlike the "physics" mode, in the "kinematics" mode the gravity and other forces
 
 ### DifferentialWheels Functions
 
-**Name**
-
-**wb\_differential\_wheels\_set\_speed** - *control the speed of the robot*
+#### `wb_differential_wheels_set_speed`
 
 [C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
@@ -138,7 +136,9 @@ double wb_differential_wheels_get_left_speed();
 double wb_differential_wheels_get_right_speed();
 ```
 
-**Description**
+##### Description
+
+*control the speed of the robot*
 
 The `wb_differential_wheels_set_speed` function allows the user to specify a speed for the [DifferentialWheels](#differentialwheels) robot.
 This speed will be sent to the motors of the robot at the beginning of the next simulation step.
@@ -152,9 +152,9 @@ The `wb_differential_wheels_get_left_speed` and `wb_differential_wheels_get_righ
 
 ---
 
-**Name**
-
-**wb\_differential\_wheels\_enable\_encoders**, **wb\_differential\_wheels\_disable\_encoders**, **wb\_differential\_wheels\_get\_encoders\_sampling\_period** - *enable or disable the incremental encoders of the robot wheels*
+#### `wb_differential_wheels_enable_encoders`
+#### `wb_differential_wheels_disable_encoders`
+#### `wb_differential_wheels_get_encoders_sampling_period`
 
 [C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
@@ -166,7 +166,9 @@ void wb_differential_wheels_disable_encoders();
 int wb_differential_wheels_get_encoders_sampling_period(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable or disable the incremental encoders of the robot wheels*
 
 These functions allow the user to enable or disable the incremental wheel encoders for both wheels of the [DifferentialWheels](#differentialwheels) robot.
 The `sampling_period` argument defines the sampling period of the encoder and is expressed in milliseconds.
@@ -183,9 +185,9 @@ Note that the first encoders values will be available only after the first sampl
 
 ---
 
-**Name**
-
-**wb\_differential\_wheels\_get\_left\_encoder**, **wb\_differential\_wheels\_get\_right\_encoder**, **wb\_differential\_wheels\_set\_encoders** - *read or set the encoders of the robot wheels*
+#### `wb_differential_wheels_get_left_encoder`
+#### `wb_differential_wheels_get_right_encoder`
+#### `wb_differential_wheels_set_encoders`
 
 [C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
@@ -197,7 +199,9 @@ double wb_differential_wheels_get_right_encoder();
 void wb_differential_wheels_set_encoders(double left, double right);
 ```
 
-**Description**
+##### Description
+
+*read or set the encoders of the robot wheels*
 
 These functions are used to read or set the values of the left and right encoders.
 The encoders must be enabled with the `wb_differential_wheels_enable_encoders` function, so that the functions can read valid data.
@@ -206,9 +210,7 @@ Setting the encoders' values will not make the wheels rotate to reach the specif
 
 ---
 
-**Name**
-
-**wb\_differential\_wheels\_get\_max\_speed** - *get the value of the maxSpeed field*
+#### `wb_differential_wheels_get_max_speed`
 
 [C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
@@ -218,15 +220,15 @@ Setting the encoders' values will not make the wheels rotate to reach the specif
 double wb_differential_wheels_get_max_speed();
 ```
 
-**Description**
+##### Description
+
+*get the value of the maxSpeed field*
 
 The `wb_differential_wheels_get_max_speed` function allows the user to get the value of the `maxSpeed` field of the [DifferentialWheels](#differentialwheels) node.
 
 ---
 
-**Name**
-
-**wb\_differential\_wheels\_get\_speed\_unit** - *get the value of the speedUnit field*
+#### `wb_differential_wheels_get_speed_unit`
 
 [C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
@@ -236,6 +238,8 @@ The `wb_differential_wheels_get_max_speed` function allows the user to get the v
 double wb_differential_wheels_get_speed_unit();
 ```
 
-**Description**
+##### Description
+
+*get the value of the speedUnit field*
 
 The `wb_differential_wheels_get_speed_unit` function allows the user to get the value of the `speedUnit` field of the [DifferentialWheels](#differentialwheels) node.

--- a/reference/display.md
+++ b/reference/display.md
@@ -59,9 +59,8 @@ Then, after closing the window, the overlay will be automatically restored.
 
 ### Display Functions
 
-**Name**
-
-**wb\_display\_get\_width**, **wb\_display\_get\_height** - *get the size of a display*
+#### `wb_display_get_width`
+#### `wb_display_get_height`
 
 [C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
@@ -72,15 +71,18 @@ int wb_display_get_width(WbDeviceTag tag);
 int wb_display_get_height(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the size of a display*
 
 These functions return respectively the values of the `width` and `height` fields.
 
 ---
 
-**Name**
-
-**wb\_display\_set\_color**, **wb\_display\_set\_alpha**, **wb\_display\_set\_opacity**, **wb\_display\_set\_font** - *set the drawing properties of a display*
+#### `wb_display_set_color`
+#### `wb_display_set_alpha`
+#### `wb_display_set_opacity`
+#### `wb_display_set_font`
 
 [C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
@@ -93,7 +95,9 @@ void wb_display_set_opacity(WbDeviceTag tag, double opacity);
 void wb_display_set_font(WbDeviceTag tag, const char *font, int size, bool anti_aliasing);
 ```
 
-**Description**
+###### Description
+
+*set the drawing properties of a display*
 
 These four functions define the context in which the subsequent drawing commands (see [draw primitive functions](#wb_display_draw_pixel)) will be applied.
 
@@ -145,9 +149,8 @@ For example the vector `[1 0 1]` represents the magenta color.
 
 ---
 
-**Name**
-
-**wb\_display\_attach\_camera**, **wb\_display\_detach\_camera** - *attach/detach a camera to a display*
+#### `wb_display_attach_camera`
+#### `wb_display_detach_camera`
 
 [C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
@@ -158,7 +161,9 @@ void wb_display_attach_camera(WbDeviceTag tag, WbDeviceTag camera_tag);
 void wb_display_detach_camera(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*attach/detach a camera to a display*
 
 These functions are used to attach/detach a camera to a display.
 When a camera is attached to a display, the camera images are efficiently copied to the background of the display.
@@ -168,9 +173,15 @@ After detaching a camera, the pixels that have not been manually drawn will be t
 
 ---
 
-**Name**
-
-**wb\_display\_draw\_pixel**, **wb\_display\_draw\_line**, **wb\_display\_draw\_rectangle**, **wb\_display\_draw\_oval**, **wb\_display\_draw\_polygon**, **wb\_display\_draw\_text**, **wb\_display\_fill\_rectangle**, **wb\_display\_fill\_oval**, **wb\_display\_fill\_polygon** - *draw a graphic primitive on a display*
+#### `wb_display_draw_pixel`
+#### `wb_display_draw_line`
+#### `wb_display_draw_rectangle`
+#### `wb_display_draw_oval`
+#### `wb_display_draw_polygon`
+#### `wb_display_draw_text`
+#### `wb_display_fill_rectangle`
+#### `wb_display_fill_oval`
+#### `wb_display_fill_polygon`
 
 [C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
@@ -188,7 +199,9 @@ void wb_display_fill_oval(WbDeviceTag tag, int cx, int cy, int a, int b);
 void wb_display_fill_polygon(WbDeviceTag tag, const int *x, const int *y, int size);
 ```
 
-**Description**
+##### Description
+
+*draw a graphic primitive on a display*
 
 These functions order the execution of a drawing primitive on a display.
 They depend on the context of the display as defined by the contextual functions (see [set context functions](#wb_display_set_color)).
@@ -229,9 +242,12 @@ The `wb_display_fill_polygon` function draws a polygon having the same propertie
 
 ---
 
-**Name**
-
-**wb\_display\_image\_new**, **wb\_display\_image\_load**, **wb\_display\_image\_copy**, **wb\_display\_image\_paste**, **wb\_display\_image\_save**, **wb\_display\_image\_delete** - *image manipulation functions*
+#### `wb_display_image_new`
+#### `wb_display_image_load`
+#### `wb_display_image_copy`
+#### `wb_display_image_paste`
+#### `wb_display_image_save`
+#### `wb_display_image_delete`
 
 [C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
@@ -246,7 +262,9 @@ void wb_display_image_save(WbDeviceTag tag, WbImageRef ir, const char *filename)
 void wb_display_image_delete(WbDeviceTag tag, WbImageRef ir);
 ```
 
-**Description**
+##### Description
+
+*image manipulation functions*
 
 In addition to the main display image, each [Display](#display) node also contains a list of clipboard images used for various image manipulations.
 This list is initially empty.

--- a/reference/display.md
+++ b/reference/display.md
@@ -63,7 +63,7 @@ Then, after closing the window, the overlay will be automatically restored.
 
 **wb\_display\_get\_width**, **wb\_display\_get\_height** - *get the size of a display*
 
-{[C++](cpp-api.md#cpp_display)}, {[Java](java-api.md#java_display)}, {[Python](python-api.md#python_display)}, {[Matlab](matlab-api.md#matlab_display)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
 ```c
 #include <webots/display.h>
@@ -82,7 +82,7 @@ These functions return respectively the values of the `width` and `height` field
 
 **wb\_display\_set\_color**, **wb\_display\_set\_alpha**, **wb\_display\_set\_opacity**, **wb\_display\_set\_font** - *set the drawing properties of a display*
 
-{[C++](cpp-api.md#cpp_display)}, {[Java](java-api.md#java_display)}, {[Python](python-api.md#python_display)}, {[Matlab](matlab-api.md#matlab_display)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
 ```c
 #include <webots/display.h>
@@ -149,7 +149,7 @@ For example the vector `[1 0 1]` represents the magenta color.
 
 **wb\_display\_attach\_camera**, **wb\_display\_detach\_camera** - *attach/detach a camera to a display*
 
-{[C++](cpp-api.md#cpp_display)}, {[Java](java-api.md#java_display)}, {[Python](python-api.md#python_display)}, {[Matlab](matlab-api.md#matlab_display)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
 ```c
 #include <webots/display.h>
@@ -172,7 +172,7 @@ After detaching a camera, the pixels that have not been manually drawn will be t
 
 **wb\_display\_draw\_pixel**, **wb\_display\_draw\_line**, **wb\_display\_draw\_rectangle**, **wb\_display\_draw\_oval**, **wb\_display\_draw\_polygon**, **wb\_display\_draw\_text**, **wb\_display\_fill\_rectangle**, **wb\_display\_fill\_oval**, **wb\_display\_fill\_polygon** - *draw a graphic primitive on a display*
 
-{[C++](cpp-api.md#cpp_display)}, {[Java](java-api.md#java_display)}, {[Python](python-api.md#python_display)}, {[Matlab](matlab-api.md#matlab_display)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
 ```c
 #include <webots/display.h>
@@ -233,7 +233,7 @@ The `wb_display_fill_polygon` function draws a polygon having the same propertie
 
 **wb\_display\_image\_new**, **wb\_display\_image\_load**, **wb\_display\_image\_copy**, **wb\_display\_image\_paste**, **wb\_display\_image\_save**, **wb\_display\_image\_delete** - *image manipulation functions*
 
-{[C++](cpp-api.md#cpp_display)}, {[Java](java-api.md#java_display)}, {[Python](python-api.md#python_display)}, {[Matlab](matlab-api.md#matlab_display)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
 ```c
 #include <webots/display.h>

--- a/reference/distancesensor.md
+++ b/reference/distancesensor.md
@@ -172,7 +172,7 @@ The ground texture must be placed in a [Plane](plane.md).
 
 **wb\_distance\_sensor\_enable**, **wb\_distance\_sensor\_disable**, **wb\_distance\_sensor\_get\_sampling\_period**, **wb\_distance\_sensor\_get\_value** - *enable, disable and read distance sensor measurements*
 
-{[C++](cpp-api.md#cpp_distance_sensor)}, {[Java](java-api.md#java_distance_sensor)}, {[Python](python-api.md#python_distance_sensor)}, {[Matlab](matlab-api.md#matlab_distance_sensor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [Matlab](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/distance_sensor.h>
@@ -203,7 +203,7 @@ Hence, the range of the return value is defined by this lookup table.
 
 **wb\_distance\_sensor\_get\_max\_value**, **wb\_distance\_sensor\_get\_min\_value**, **wb\_distance\_sensor\_get\_aperture** - *Get the maximum value, minimum value and aperture*
 
-{[C++](cpp-api.md#cpp_distance_sensor)}, {[Java](java-api.md#java_distance_sensor)}, {[Python](python-api.md#python_distance_sensor)}, {[Matlab](matlab-api.md#matlab_distance_sensor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [Matlab](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/distance_sensor.h>
@@ -229,7 +229,7 @@ The `wb_distance_sensor_get_aperture` function returns the aperture of the dista
 
 **wb\_distance\_sensor\_get\_type** - *Return the sensor type*
 
-{[C++](cpp-api.md#cpp_distance_sensor)}, {[Java](java-api.md#java_distance_sensor)}, {[Python](python-api.md#python_distance_sensor)}, {[Matlab](matlab-api.md#matlab_distance_sensor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [Matlab](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/distance_sensor.h>

--- a/reference/distancesensor.md
+++ b/reference/distancesensor.md
@@ -168,9 +168,10 @@ The ground texture must be placed in a [Plane](plane.md).
 
 ### DistanceSensor Functions
 
-**Name**
-
-**wb\_distance\_sensor\_enable**, **wb\_distance\_sensor\_disable**, **wb\_distance\_sensor\_get\_sampling\_period**, **wb\_distance\_sensor\_get\_value** - *enable, disable and read distance sensor measurements*
+#### `wb_distance_sensor_enable`
+#### `wb_distance_sensor_disable`
+#### `wb_distance_sensor_get_sampling_period`
+#### `wb_distance_sensor_get_value`
 
 [C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [Matlab](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
 
@@ -183,7 +184,9 @@ int wb_distance_sensor_get_sampling_period(WbDeviceTag tag);
 double wb_distance_sensor_get_value(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable, disable and read distance sensor measurements*
 
 The `wb_distance_sensor_enable` function allows the user to enable distance sensor measurements.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.
@@ -199,9 +202,9 @@ Hence, the range of the return value is defined by this lookup table.
 
 ---
 
-**Name**
-
-**wb\_distance\_sensor\_get\_max\_value**, **wb\_distance\_sensor\_get\_min\_value**, **wb\_distance\_sensor\_get\_aperture** - *Get the maximum value, minimum value and aperture*
+#### `wb_distance_sensor_get_max_value`
+#### `wb_distance_sensor_get_min_value`
+#### `wb_distance_sensor_get_aperture`
 
 [C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [Matlab](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
 
@@ -213,7 +216,9 @@ double wb_distance_sensor_get_min_value(WbDeviceTag tag);
 double wb_distance_sensor_get_aperture(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*Get the maximum value, minimum value and aperture*
 
 The `wb_distance_sensor_get_max_value` function returns the maximum value which can be returned by the distance sensor.
 This value is the maximum of the second column of the `DistanceSensor.lookupTable` field.
@@ -225,9 +230,7 @@ The `wb_distance_sensor_get_aperture` function returns the aperture of the dista
 
 ---
 
-**Name**
-
-**wb\_distance\_sensor\_get\_type** - *Return the sensor type*
+#### `wb_distance_sensor_get_type`
 
 [C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [Matlab](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
 
@@ -237,7 +240,9 @@ The `wb_distance_sensor_get_aperture` function returns the aperture of the dista
 int wb_distance_sensor_get_type(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*Return the sensor type*
 
 This function allows the user to retrieve the distance sensor type defined by the `type` field.
 If the value of the `type` field is "laser" then this function returns WB\_DISTANCE\_SENSOR\_LASER, if it is "infra-red" then it returns WB\_DISTANCE\_SENSOR\_INFRA\_RED, if it is "sonar" then it returns WB\_DISTANCE\_SENSOR\_SONAR and otherwise it returns WB\_DISTANCE\_SENSOR\_GENERIC.

--- a/reference/emitter.md
+++ b/reference/emitter.md
@@ -81,7 +81,7 @@ In addition it is highly recommended to choose -1 for the baudRate, in order to 
 
 **wb\_emitter\_send** - *send a data packet to potential receivers*
 
-{[C++](cpp-api.md#cpp_emitter)}, {[Java](java-api.md#java_emitter)}, {[Python](python-api.md#python_emitter)}, {[Matlab](matlab-api.md#matlab_emitter)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
 ```c
 #include <webots/emitter.h>
@@ -149,7 +149,7 @@ Here is an example of sending a Java string in a way that is compatible with a C
 
 **wb\_emitter\_set\_channel**, **wb\_emitter\_get\_channel** - *set and get the emitter's channel.*
 
-{[C++](cpp-api.md#cpp_emitter)}, {[Java](java-api.md#java_emitter)}, {[Python](python-api.md#python_emitter)}, {[Matlab](matlab-api.md#matlab_emitter)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
 ```c
 #include <webots/emitter.h>
@@ -175,7 +175,7 @@ The `wb_emitter_get_channel` function returns the current channel number of the 
 
 **wb\_emitter\_set\_range**, **wb\_emitter\_get\_range** - *set and get the emitter's range.*
 
-{[C++](cpp-api.md#cpp_emitter)}, {[Java](java-api.md#java_emitter)}, {[Python](python-api.md#python_emitter)}, {[Matlab](matlab-api.md#matlab_emitter)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
 ```c
 #include <webots/emitter.h>
@@ -199,7 +199,7 @@ For both the `wb_emitter_set_range` and `emitter_get_range` functions, a value o
 
 **wb\_emitter\_get\_buffer\_size** - *get the transmission buffer size*
 
-{[C++](cpp-api.md#cpp_emitter)}, {[Java](java-api.md#java_emitter)}, {[Python](python-api.md#python_emitter)}, {[Matlab](matlab-api.md#matlab_emitter)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
 ```c
 #include <webots/emitter.h>

--- a/reference/emitter.md
+++ b/reference/emitter.md
@@ -77,9 +77,7 @@ In addition it is highly recommended to choose -1 for the baudRate, in order to 
 
 ### Emitter Functions
 
-**Name**
-
-**wb\_emitter\_send** - *send a data packet to potential receivers*
+#### `wb_emitter_send`
 
 [C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
@@ -89,7 +87,9 @@ In addition it is highly recommended to choose -1 for the baudRate, in order to 
 int wb_emitter_send(WbDeviceTag tag, const void *data, int size);
 ```
 
-**Description**
+##### Description
+
+*send a data packet to potential receivers*
 
 The `wb_emitter_send` function adds to the emitter's queue a packet of `size` bytes located at the address indicated by `data`.
 The enqueued data packets will then be sent to potential receivers (and removed from the emitter's queue) at the rate specified by the `baudRate` field of the [Emitter](#emitter) node.
@@ -145,9 +145,8 @@ Here is an example of sending a Java string in a way that is compatible with a C
 
 ---
 
-**Name**
-
-**wb\_emitter\_set\_channel**, **wb\_emitter\_get\_channel** - *set and get the emitter's channel.*
+#### `wb_emitter_set_channel`
+#### `wb_emitter_get_channel`
 
 [C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
@@ -158,7 +157,9 @@ void wb_emitter_set_channel(WbDeviceTag tag, int channel);
 int wb_emitter_get_channel(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*set and get the emitter's channel.*
 
 The `wb_emitter_set_channel` function allows the controller to change the transmission channel.
 This modifies the `channel` field of the corresponding [Emitter](#emitter) node.
@@ -171,9 +172,8 @@ The `wb_emitter_get_channel` function returns the current channel number of the 
 
 ---
 
-**Name**
-
-**wb\_emitter\_set\_range**, **wb\_emitter\_get\_range** - *set and get the emitter's range.*
+#### `wb_emitter_set_range`
+#### `wb_emitter_get_range`
 
 [C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
@@ -184,7 +184,9 @@ void wb_emitter_set_range(WbDeviceTag tag, double range);
 double wb_emitter_get_range(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*set and get the emitter's range.*
 
 The `wb_emitter_set_range` function allows the controller to change the transmission range at run-time.
 Data packets can only reach receivers located within the emitter's range.
@@ -195,9 +197,7 @@ For both the `wb_emitter_set_range` and `emitter_get_range` functions, a value o
 
 ---
 
-**Name**
-
-**wb\_emitter\_get\_buffer\_size** - *get the transmission buffer size*
+#### `wb_emitter_get_buffer_size`
 
 [C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
@@ -207,7 +207,9 @@ For both the `wb_emitter_set_range` and `emitter_get_range` functions, a value o
 int wb_emitter_get_buffer_size(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the transmission buffer size*
 
 The `wb_emitter_get_buffer_size` function returns the size (in bytes) of the transmission buffer.
 This corresponds to the value specified by the `bufferSize` field of the [Emitter](#emitter) node.

--- a/reference/gps.md
+++ b/reference/gps.md
@@ -46,9 +46,11 @@ This field accepts any value in the interval (0.0, inf).
 
 ### GPS Functions
 
-**Name**
-
-**wb\_gps\_enable**, **wb\_gps\_disable**, **wb\_gps\_get\_sampling\_period**, **wb\_gps\_get\_values**, **wb\_gps\_get\_speed** - *enable, disable and read the GPS measurements*
+#### `wb_gps_enable`
+#### `wb_gps_disable`
+#### `wb_gps_get_sampling_period`
+#### `wb_gps_get_values`
+#### `wb_gps_get_speed`
 
 [C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [Matlab](matlab-api.md#matlab_gps) [ROS](ros-api.md)
 
@@ -62,7 +64,9 @@ const double *wb_gps_get_values(WbDeviceTag tag);
 const double wb_gps_get_speed(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable, disable and read the GPS measurements*
 
 The `wb_gps_enable` function allows the user to enable GPS measurements.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.
@@ -90,9 +94,7 @@ If these values are needed for a longer period they must be copied.
 
 ---
 
-**Name**
-
-**wb\_gps\_get\_coordinate\_system** - *get the gps coordinate system*
+#### `wb_gps_get_coordinate_system`
 
 [C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [Matlab](matlab-api.md#matlab_gps) [ROS](ros-api.md)
 
@@ -102,16 +104,16 @@ If these values are needed for a longer period they must be copied.
 int wb_gps_get_coordinate_system(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the gps coordinate system*
 
 This function allows the user to retrieve the coordinate system type defined by the `gpsCoordinateSystem` field of the [WorldInfo](worldinfo.md) node.
 If the value of the `gpsCoordinateSystem` field is "local" then this function returns WB\_GPS\_LOCAL\_COORDINATE, and otherwise it returns WB\_GPS\_WGS84\_COORDINATE.
 
 ---
 
-**Name**
-
-**wb\_gps\_convert\_to\_degrees\_minutes\_seconds** - *convert decimal degrees to degrees minutes seconds*
+#### `wb_gps_convert_to_degrees_minutes_seconds`
 
 [C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [Matlab](matlab-api.md#matlab_gps) [ROS](ros-api.md)
 
@@ -121,7 +123,9 @@ If the value of the `gpsCoordinateSystem` field is "local" then this function re
 const char * wb_gps_convert_to_degrees_minutes_seconds(double decimal_degrees);
 ```
 
-**Description**
+##### Description
+
+*convert decimal degrees to degrees minutes seconds*
 
 This function converts a decimal degrees coordinate into a string representing the coordinate in the degrees minutes seconds format.
 

--- a/reference/gps.md
+++ b/reference/gps.md
@@ -50,7 +50,7 @@ This field accepts any value in the interval (0.0, inf).
 
 **wb\_gps\_enable**, **wb\_gps\_disable**, **wb\_gps\_get\_sampling\_period**, **wb\_gps\_get\_values**, **wb\_gps\_get\_speed** - *enable, disable and read the GPS measurements*
 
-{[C++](cpp-api.md#cpp_gps)}, {[Java](java-api.md#java_gps)}, {[Python](python-api.md#python_gps)}, {[Matlab](matlab-api.md#matlab_gps)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [Matlab](matlab-api.md#matlab_gps) [ROS](ros-api.md)
 
 ```c
 #include <webots/gps.h>
@@ -94,7 +94,7 @@ If these values are needed for a longer period they must be copied.
 
 **wb\_gps\_get\_coordinate\_system** - *get the gps coordinate system*
 
-{[C++](cpp-api.md#cpp_gps)}, {[Java](java-api.md#java_gps)}, {[Python](python-api.md#python_gps)}, {[Matlab](matlab-api.md#matlab_gps)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [Matlab](matlab-api.md#matlab_gps) [ROS](ros-api.md)
 
 ```c
 #include <webots/gps.h>
@@ -113,7 +113,7 @@ If the value of the `gpsCoordinateSystem` field is "local" then this function re
 
 **wb\_gps\_convert\_to\_degrees\_minutes\_seconds** - *convert decimal degrees to degrees minutes seconds*
 
-{[C++](cpp-api.md#cpp_gps)}, {[Java](java-api.md#java_gps)}, {[Python](python-api.md#python_gps)}, {[Matlab](matlab-api.md#matlab_gps)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [Matlab](matlab-api.md#matlab_gps) [ROS](ros-api.md)
 
 ```c
 #include <webots/gps.h>

--- a/reference/gyro.md
+++ b/reference/gyro.md
@@ -34,9 +34,10 @@ This field accepts any value in the interval (0.0, inf).
 
 ### Gyro Functions
 
-**Name**
-
-**wb\_gyro\_enable**, **wb\_gyro\_disable**, **wb\_gyro\_get\_sampling\_period**, **wb\_gyro\_get\_values** - *enable, disable and read the output values of the gyro device*
+#### `wb_gyro_enable`
+#### `wb_gyro_disable`
+#### `wb_gyro_get_sampling_period`
+#### `wb_gyro_get_values`
 
 [C++](cpp-api.md#cpp_gyro) [Java](java-api.md#java_gyro) [Python](python-api.md#python_gyro) [Matlab](matlab-api.md#matlab_gyro) [ROS](ros-api.md)
 
@@ -49,7 +50,9 @@ int wb_gyro_get_sampling_period(WbDeviceTag tag);
 const double *wb_gyro_get_values(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable, disable and read the output values of the gyro device*
 
 The `wb_gyro_enable` function turns on the angular velocity measurements.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.

--- a/reference/gyro.md
+++ b/reference/gyro.md
@@ -38,7 +38,7 @@ This field accepts any value in the interval (0.0, inf).
 
 **wb\_gyro\_enable**, **wb\_gyro\_disable**, **wb\_gyro\_get\_sampling\_period**, **wb\_gyro\_get\_values** - *enable, disable and read the output values of the gyro device*
 
-{[C++](cpp-api.md#cpp_gyro)}, {[Java](java-api.md#java_gyro)}, {[Python](python-api.md#python_gyro)}, {[Matlab](matlab-api.md#matlab_gyro)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_gyro) [Java](java-api.md#java_gyro) [Python](python-api.md#python_gyro) [Matlab](matlab-api.md#matlab_gyro) [ROS](ros-api.md)
 
 ```c
 #include <webots/gyro.h>

--- a/reference/inertialunit.md
+++ b/reference/inertialunit.md
@@ -53,9 +53,10 @@ This field accepts any value in the interval (0.0, inf).
 
 ### InertialUnit Functions
 
-**Name**
-
-**wb\_inertial\_unit\_enable**, **wb\_inertial\_unit\_disable**, **wb\_inertial\_unit\_get\_sampling\_period**, **wb\_inertial\_unit\_get\_roll\_pitch\_yaw** - *enable, disable and read the output values of the inertial unit*
+#### `wb_inertial_unit_enable`
+#### `wb_inertial_unit_disable`
+#### `wb_inertial_unit_get_sampling_period`
+#### `wb_inertial_unit_get_roll_pitch_yaw`
 
 [C++](cpp-api.md#cpp_inertial_unit) [Java](java-api.md#java_inertial_unit) [Python](python-api.md#python_inertial_unit) [Matlab](matlab-api.md#matlab_inertial_unit) [ROS](ros-api.md)
 
@@ -68,7 +69,9 @@ int wb_inertial_unit_get_sampling_period(WbDeviceTag tag);
 const double *wb_inertial_unit_get_roll_pitch_yaw(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable, disable and read the output values of the inertial unit*
 
 The `wb_inertial_unit_enable` function turns on the angle measurements.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.

--- a/reference/inertialunit.md
+++ b/reference/inertialunit.md
@@ -69,7 +69,7 @@ int wb_inertial_unit_get_sampling_period(WbDeviceTag tag);
 const double *wb_inertial_unit_get_roll_pitch_yaw(WbDeviceTag tag);
 ```
 
-##### Description
+##### Description
 
 *enable, disable and read the output values of the inertial unit*
 

--- a/reference/inertialunit.md
+++ b/reference/inertialunit.md
@@ -57,7 +57,7 @@ This field accepts any value in the interval (0.0, inf).
 
 **wb\_inertial\_unit\_enable**, **wb\_inertial\_unit\_disable**, **wb\_inertial\_unit\_get\_sampling\_period**, **wb\_inertial\_unit\_get\_roll\_pitch\_yaw** - *enable, disable and read the output values of the inertial unit*
 
-{[C++](cpp-api.md#cpp_inertial_unit)}, {[Java](java-api.md#java_inertial_unit)}, {[Python](python-api.md#python_inertial_unit)}, {[Matlab](matlab-api.md#matlab_inertial_unit)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_inertial_unit) [Java](java-api.md#java_inertial_unit) [Python](python-api.md#python_inertial_unit) [Matlab](matlab-api.md#matlab_inertial_unit) [ROS](ros-api.md)
 
 ```c
 #include <webots/inertial_unit.h>

--- a/reference/joystick.md
+++ b/reference/joystick.md
@@ -16,7 +16,7 @@ In order to get the `Joystick` instance, you should call the `getJoystick` funct
 
 **wb\_joystick\_enable**, **wb\_joystick\_disable**, **wb\_joystick\_get\_sampling\_period** - *enable/disable joystick*
 
-{[C++](cpp-api.md#cpp_joystick)}, {[Java](java-api.md#java_joystick)}, {[Python](python-api.md#python_joystick)}, {[Matlab](matlab-api.md#matlab_joystick)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>
@@ -44,7 +44,7 @@ The `wb_joystick_get_sampling_period` function returns the value previously pass
 
 **wb\_joystick\_is\_connected** - *check if a joystick is paired with this controller*
 
-{[C++](cpp-api.md#cpp_joystick)}, {[Java](java-api.md#java_joystick)}, {[Python](python-api.md#python_joystick)}, {[Matlab](matlab-api.md#matlab_joystick)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>
@@ -62,7 +62,7 @@ Once the joystick is enabled, this function can be used to check if a free joyst
 
 **wb\_joystick\_get\_model** - *get the model of the currently connected joystick*
 
-{[C++](cpp-api.md#cpp_joystick)}, {[Java](java-api.md#java_joystick)}, {[Python](python-api.md#python_joystick)}, {[Matlab](matlab-api.md#matlab_joystick)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>
@@ -82,7 +82,7 @@ The returned model of the joystick may looks like: `Logitech G29 Driving Force R
 
 **wb\_joystick\_get\_number\_of\_axes**, **wb\_joystick\_get\_axis\_value** - *get number of axes and axis value*
 
-{[C++](cpp-api.md#cpp_joystick)}, {[Java](java-api.md#java_joystick)}, {[Python](python-api.md#python_joystick)}, {[Matlab](matlab-api.md#matlab_joystick)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>
@@ -103,7 +103,7 @@ The `wb_joystick_get_axis_value` function returns the current value of the axis 
 
 **wb\_joystick\_get\_pressed\_button** - *get the buttons pressed on the joystick*
 
-{[C++](cpp-api.md#cpp_joystick)}, {[Java](java-api.md#java_joystick)}, {[Python](python-api.md#python_joystick)}, {[Matlab](matlab-api.md#matlab_joystick)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>
@@ -127,7 +127,7 @@ On macOS, only the first 12 buttons and first 2 axes of the joystick are taken i
 
 **wb\_joystick\_set\_constant\_force**, **wb\_joystick\_set\_constant\_force\_duration**, **wb\_joystick\_set\_auto\_centering\_gain**, **wb\_joystick\_set\_resistance\_gain** - *set the force feedback parameters*
 
-{[C++](cpp-api.md#cpp_joystick)}, {[Java](java-api.md#java_joystick)}, {[Python](python-api.md#python_joystick)}, {[Matlab](matlab-api.md#matlab_joystick)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>

--- a/reference/joystick.md
+++ b/reference/joystick.md
@@ -12,9 +12,9 @@ In order to get the `Joystick` instance, you should call the `getJoystick` funct
 
 ### Joystick Functions
 
-**Name**
-
-**wb\_joystick\_enable**, **wb\_joystick\_disable**, **wb\_joystick\_get\_sampling\_period** - *enable/disable joystick*
+#### `wb_joystick_enable`
+#### `wb_joystick_disable`
+#### `wb_joystick_get_sampling_period`
 
 [C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
@@ -26,7 +26,9 @@ void wb_joystick_disable();
 int wb_joystick_get_sampling_period();
 ```
 
-**Description**
+##### Description
+
+*enable/disable joystick*
 
 The `wb_joystick_enable` function allows the user to enable joystick measurements.
 When this function is called the first free joystick is paired with the controller.
@@ -40,9 +42,7 @@ The `wb_joystick_get_sampling_period` function returns the value previously pass
 
 ---
 
-**Name**
-
-**wb\_joystick\_is\_connected** - *check if a joystick is paired with this controller*
+#### `wb_joystick_is_connected`
 
 [C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
@@ -52,15 +52,15 @@ The `wb_joystick_get_sampling_period` function returns the value previously pass
 bool wb_joystick_is_connected(int ms);
 ```
 
-**Description**
+##### Description
+
+*check if a joystick is paired with this controller*
 
 Once the joystick is enabled, this function can be used to check if a free joystick has been paired with the controller or if no available joystick was found.
 
 ---
 
-**Name**
-
-**wb\_joystick\_get\_model** - *get the model of the currently connected joystick*
+#### `wb_joystick_get_model`
 
 [C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
@@ -70,7 +70,9 @@ Once the joystick is enabled, this function can be used to check if a free joyst
 const char *wb_joystick_get_model();
 ```
 
-**Description**
+##### Description
+
+*get the model of the currently connected joystick*
 
 When a joystick is connected to the controller, this function returns the model of the joystick.
 If no joystick is connected to the controller, a NULL pointer is returned instead.
@@ -78,9 +80,8 @@ The returned model of the joystick may looks like: `Logitech G29 Driving Force R
 
 ---
 
-**Name**
-
-**wb\_joystick\_get\_number\_of\_axes**, **wb\_joystick\_get\_axis\_value** - *get number of axes and axis value*
+#### `wb_joystick_get_number_of_axes`
+#### `wb_joystick_get_axis_value`
 
 [C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
@@ -91,7 +92,9 @@ int  wb_joystick_get_number_of_axes();
 int  wb_joystick_get_axis_value(int axis);
 ```
 
-**Description**
+##### Description
+
+*get number of axes and axis value*
 
 The `wb_joystick_get_number_of_axes` function returns the number of axes of the joystick.
 
@@ -99,9 +102,7 @@ The `wb_joystick_get_axis_value` function returns the current value of the axis 
 
 ---
 
-**Name**
-
-**wb\_joystick\_get\_pressed\_button** - *get the buttons pressed on the joystick*
+#### `wb_joystick_get_pressed_button`
 
 [C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
@@ -111,7 +112,9 @@ The `wb_joystick_get_axis_value` function returns the current value of the axis 
 int wb_joystick_get_pressed_button();
 ```
 
-**Description**
+##### Description
+
+*get the buttons pressed on the joystick*
 
 This function allows you to read a button pressed on the joystick paired with this controller (if any).
 The Webots window must be selected and the simulation must be running.
@@ -123,9 +126,10 @@ On macOS, only the first 12 buttons and first 2 axes of the joystick are taken i
 
 ---
 
-**Name**
-
-**wb\_joystick\_set\_constant\_force**, **wb\_joystick\_set\_constant\_force\_duration**, **wb\_joystick\_set\_auto\_centering\_gain**, **wb\_joystick\_set\_resistance\_gain** - *set the force feedback parameters*
+#### `wb_joystick_set_constant_force`
+#### `wb_joystick_set_constant_force_duration`
+#### `wb_joystick_set_auto_centering_gain`
+#### `wb_joystick_set_resistance_gain`
 
 [C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
@@ -138,7 +142,9 @@ void wb_joystick_set_auto_centering_gain(double gain);
 void wb_joystick_set_resistance_gain(double gain);
 ```
 
-**Description**
+##### Description
+
+*set the force feedback parameters*
 
 The `wb_joystick_set_constant_force` function uses the joystick force feedback to add a constant force on an axis.
 The joystick must support force feedback and the unit of `level` is hardware specific.

--- a/reference/keyboard.md
+++ b/reference/keyboard.md
@@ -8,9 +8,10 @@ In order to get the `Keyboard` instance, you should call the `getKeyboard` funct
 
 ### Keyboard Functions
 
-**Name**
-
-**wb\_keyboard\_enable**, **wb\_keyboard\_disable**, **wb\_keyboard\_get\_sampling\_period**, **wb\_keyboard\_get\_key** - *keyboard reading function*
+#### `wb_keyboard_enable`
+#### `wb_keyboard_disable`
+#### `wb_keyboard_get_sampling_period`
+#### `wb_keyboard_get_key`
 
 [C++](cpp-api.md#cpp_keyboard) [Java](java-api.md#java_keyboard) [Python](python-api.md#python_keyboard) [Matlab](matlab-api.md#matlab_keyboard) [ROS](ros-api.md)
 
@@ -23,7 +24,9 @@ int wb_keyboard_get_sampling_period();
 int wb_keyboard_get_key();
 ```
 
-**Description**
+##### Description
+
+*keyboard reading function*
 
 These functions allow you to read a key pressed on the computer keyboard from a controller program while the 3D window of Webots is selected and the simulation is running.
 First, it is necessary to enable keyboard input by calling the `wb_keyboard_enable` function.

--- a/reference/keyboard.md
+++ b/reference/keyboard.md
@@ -12,7 +12,7 @@ In order to get the `Keyboard` instance, you should call the `getKeyboard` funct
 
 **wb\_keyboard\_enable**, **wb\_keyboard\_disable**, **wb\_keyboard\_get\_sampling\_period**, **wb\_keyboard\_get\_key** - *keyboard reading function*
 
-{[C++](cpp-api.md#cpp_keyboard)}, {[Java](java-api.md#java_keyboard)}, {[Python](python-api.md#python_keyboard)}, {[Matlab](matlab-api.md#matlab_keyboard)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_keyboard) [Java](java-api.md#java_keyboard) [Python](python-api.md#python_keyboard) [Matlab](matlab-api.md#matlab_keyboard) [ROS](ros-api.md)
 
 ```c
 #include <webots/keyboard.h>

--- a/reference/led.md
+++ b/reference/led.md
@@ -37,9 +37,8 @@ If the `color` list contains a single color, then the LED is monochromatic, and 
 
 ### LED Functions
 
-**Name**
-
-**wb\_led\_set**, **wb\_led\_get** - *turn an LED on or off and read its status*
+#### `wb_led_set`
+#### `wb_led_get`
 
 [C++](cpp-api.md#cpp_led) [Java](java-api.md#java_led) [Python](python-api.md#python_led) [Matlab](matlab-api.md#matlab_led) [ROS](ros-api.md)
 
@@ -50,7 +49,9 @@ void wb_led_set(WbDeviceTag tag, int value);
 int wb_led_get(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*turn an LED on or off and read its status*
 
 The `wb_led_set` function switches an LED on or off, possibly changing its color.
 If the `value` parameter is 0, the LED is turned off.

--- a/reference/led.md
+++ b/reference/led.md
@@ -41,7 +41,7 @@ If the `color` list contains a single color, then the LED is monochromatic, and 
 
 **wb\_led\_set**, **wb\_led\_get** - *turn an LED on or off and read its status*
 
-{[C++](cpp-api.md#cpp_led)}, {[Java](java-api.md#java_led)}, {[Python](python-api.md#python_led)}, {[Matlab](matlab-api.md#matlab_led)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_led) [Java](java-api.md#java_led) [Python](python-api.md#python_led) [Matlab](matlab-api.md#matlab_led) [ROS](ros-api.md)
 
 ```c
 #include <webots/led.h>

--- a/reference/lidar.md
+++ b/reference/lidar.md
@@ -139,7 +139,7 @@ The same comment applies to the horizontal resolution, the internal depth camera
 
 **wb\_lidar\_enable**, **wb\_lidar\_disable**, **wb\_lidar\_get\_sampling\_period** - *enable and disable lidar updates*
 
-{[C++](cpp-api.md#cpp_lidar)}, {[Java](java-api.md#java_lidar)}, {[Python](python-api.md#python_lidar)}, {[Matlab](matlab-api.md#matlab_lidar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -165,7 +165,7 @@ The `wb_lidar_get_sampling_period` function returns the period given into the `w
 
 **wb\_lidar\_enable\_point\_cloud**, **wb\_lidar\_disable\_point\_cloud**, **wb\_lidar\_is\_point\_cloud\_enabled** - *enable and disable lidar point cloud mode*
 
-{[C++](cpp-api.md#cpp_lidar)}, {[Java](java-api.md#java_lidar)}, {[Python](python-api.md#python_lidar)}, {[Matlab](matlab-api.md#matlab_lidar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -192,7 +192,7 @@ First the lidar should be enabled using the `wb_lidar_enable` function.
 
 **wb\_lidar\_get\_range\_image**, **wb\_lidar\_get\_layer\_range\_image** - *get the range image and range image associate with a specific layer*
 
-{[C++](cpp-api.md#cpp_lidar)}, {[Java](java-api.md#java_lidar)}, {[Python](python-api.md#python_lidar)}, {[Matlab](matlab-api.md#matlab_lidar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -229,7 +229,7 @@ Their content are identical but their handling is of course different.
 
 **wb\_lidar\_get\_point\_cloud**, **wb\_lidar\_get\_layer\_point\_cloud**, **wb\_lidar\_get\_number\_of\_points** - *get the points array, points array associate with a specific layer and total number of point*
 
-{[C++](cpp-api.md#cpp_lidar)}, {[Java](java-api.md#java_lidar)}, {[Python](python-api.md#python_lidar)}, {[Matlab](matlab-api.md#matlab_lidar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -261,7 +261,7 @@ The `wb_lidar_get_number_of_points` function returns the total number of points 
 
 **wb\_lidar\_get\_frequency**, **wb\_lidar\_set\_frequency** - *set and get the rotating frequency*
 
-{[C++](cpp-api.md#cpp_lidar)}, {[Java](java-api.md#java_lidar)}, {[Python](python-api.md#python_lidar)}, {[Matlab](matlab-api.md#matlab_lidar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -283,7 +283,7 @@ The `frequency` argument should be in the range [minFrequency; maxFrequency].
 
 **wb\_lidar\_get\_horizontal\_resolution**, **wb\_lidar\_get\_number\_of\_layers** - *get the horizontal resolution and layer number*
 
-{[C++](cpp-api.md#cpp_lidar)}, {[Java](java-api.md#java_lidar)}, {[Python](python-api.md#python_lidar)}, {[Matlab](matlab-api.md#matlab_lidar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -304,7 +304,7 @@ The `wb_lidar_get_number_of_layers` function returns the number of layers of the
 
 **wb\_lidar\_get\_min\_frequency**, **wb\_lidar\_get\_max\_frequency** - *get the minimum and maximum rotating frequency*
 
-{[C++](cpp-api.md#cpp_lidar)}, {[Java](java-api.md#java_lidar)}, {[Python](python-api.md#python_lidar)}, {[Matlab](matlab-api.md#matlab_lidar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -323,7 +323,7 @@ The `wb_lidar_get_min_frequency` and `wb_lidar_get_max_frequency` functions retu
 
 **wb\_lidar\_get\_fov**, **wb\_lidar\_get\_vertical\_fov** - *get the horizontal and vertical field of view of the lidar*
 
-{[C++](cpp-api.md#cpp_lidar)}, {[Java](java-api.md#java_lidar)}, {[Python](python-api.md#python_lidar)}, {[Matlab](matlab-api.md#matlab_lidar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -344,7 +344,7 @@ The `wb_lidar_get_vertical_fov` function returns the vertical field of view of t
 
 **wb\_lidar\_get\_min\_range**, **wb\_lidar\_get\_max\_range** - *get the minimum and maximum range*
 
-{[C++](cpp-api.md#cpp_lidar)}, {[Java](java-api.md#java_lidar)}, {[Python](python-api.md#python_lidar)}, {[Matlab](matlab-api.md#matlab_lidar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>

--- a/reference/lidar.md
+++ b/reference/lidar.md
@@ -135,9 +135,9 @@ The same comment applies to the horizontal resolution, the internal depth camera
 
 ### Lidar Functions
 
-**Name**
-
-**wb\_lidar\_enable**, **wb\_lidar\_disable**, **wb\_lidar\_get\_sampling\_period** - *enable and disable lidar updates*
+#### `wb_lidar_enable`
+#### `wb_lidar_disable`
+#### `wb_lidar_get_sampling_period`
 
 [C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
@@ -149,7 +149,9 @@ void wb_lidar_disable(WbDeviceTag tag);
 int wb_lidar_get_sampling_period(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable and disable lidar updates*
 
 The `wb_lidar_enable` function allows the user to enable lidar updates.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.
@@ -161,9 +163,9 @@ The `wb_lidar_get_sampling_period` function returns the period given into the `w
 
 ---
 
-**Name**
-
-**wb\_lidar\_enable\_point\_cloud**, **wb\_lidar\_disable\_point\_cloud**, **wb\_lidar\_is\_point\_cloud\_enabled** - *enable and disable lidar point cloud mode*
+#### `wb_lidar_enable_point_cloud`
+#### `wb_lidar_disable_point_cloud`
+#### `wb_lidar_is_point_cloud_enabled`
 
 [C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
@@ -175,7 +177,9 @@ void wb_lidar_disable_point_cloud(WbDeviceTag tag);
 bool wb_lidar_is_point_cloud_enabled(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable and disable lidar point cloud mode*
 
 The `wb_lidar_enable_point_cloud` function allows the user to enable the lidar point cloud update, the point cloud array is then updated with the same sampling period as the range image.
 
@@ -188,9 +192,8 @@ First the lidar should be enabled using the `wb_lidar_enable` function.
 
 ---
 
-**Name**
-
-**wb\_lidar\_get\_range\_image**, **wb\_lidar\_get\_layer\_range\_image** - *get the range image and range image associate with a specific layer*
+#### `wb_lidar_get_range_image`
+#### `wb_lidar_get_layer_range_image`
 
 [C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
@@ -201,7 +204,9 @@ const float *wb_lidar_get_range_image(WbDeviceTag tag);
 const float *wb_lidar_get_layer_range_image(WbDeviceTag tag, int layer);
 ```
 
-**Description**
+##### Description
+
+*get the range image and range image associate with a specific layer*
 
 The `wb_lidar_get_range_image` function allows the user to read the contents of the last range image grabbed by a lidar.
 The range image is computed using the depth buffer produced by the OpenGL rendering.
@@ -225,9 +230,9 @@ Their content are identical but their handling is of course different.
 
 ---
 
-**Name**
-
-**wb\_lidar\_get\_point\_cloud**, **wb\_lidar\_get\_layer\_point\_cloud**, **wb\_lidar\_get\_number\_of\_points** - *get the points array, points array associate with a specific layer and total number of point*
+#### `wb_lidar_get_point_cloud`
+#### `wb_lidar_get_layer_point_cloud`
+#### `wb_lidar_get_number_of_points`
 
 [C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
@@ -239,7 +244,9 @@ const WbLidarPoint *wb_lidar_get_layer_point_cloud(WbDeviceTag tag, int layer);
 int wb_lidar_get_number_of_points(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the points array, points array associate with a specific layer and total number of point*
 
 The `wb_lidar_get_point_cloud` function returns the pointer to the point cloud array, each point consists of a [`WbLidarPoint`](#wblidarpoint).
 The memory chunk returned by this function shall not be freed, as it is managed by the lidar internally.
@@ -257,9 +264,8 @@ The `wb_lidar_get_number_of_points` function returns the total number of points 
 
 ---
 
-**Name**
-
-**wb\_lidar\_get\_frequency**, **wb\_lidar\_set\_frequency** - *set and get the rotating frequency*
+#### `wb_lidar_get_frequency`
+#### `wb_lidar_set_frequency`
 
 [C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
@@ -270,7 +276,9 @@ double wb_lidar_get_frequency(WbDeviceTag tag);
 void wb_lidar_set_frequency(WbDeviceTag tag, double frequency);
 ```
 
-**Description**
+##### Description
+
+*set and get the rotating frequency*
 
 The `wb_lidar_get_frequency` function returns the current rotating frequency of the lidar head (in case of rotating lidar).
 
@@ -279,9 +287,8 @@ The `frequency` argument should be in the range [minFrequency; maxFrequency].
 
 ---
 
-**Name**
-
-**wb\_lidar\_get\_horizontal\_resolution**, **wb\_lidar\_get\_number\_of\_layers** - *get the horizontal resolution and layer number*
+#### `wb_lidar_get_horizontal_resolution`
+#### `wb_lidar_get_number_of_layers`
 
 [C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
@@ -292,7 +299,9 @@ int wb_lidar_get_horizontal_resolution(WbDeviceTag tag);
 int wb_lidar_get_number_of_layers(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the horizontal resolution and layer number*
 
 The `wb_lidar_get_horizontal_resolution` function returns the horizontal resolution of the lidar.
 
@@ -300,9 +309,8 @@ The `wb_lidar_get_number_of_layers` function returns the number of layers of the
 
 ---
 
-**Name**
-
-**wb\_lidar\_get\_min\_frequency**, **wb\_lidar\_get\_max\_frequency** - *get the minimum and maximum rotating frequency*
+#### `wb_lidar_get_min_frequency`
+#### `wb_lidar_get_max_frequency`
 
 [C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
@@ -313,15 +321,16 @@ double wb_lidar_get_min_frequency(WbDeviceTag tag);
 double wb_lidar_get_max_frequency(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the minimum and maximum rotating frequency*
 
 The `wb_lidar_get_min_frequency` and `wb_lidar_get_max_frequency` functions return respectively the minimum and maximum allowed rotating frequency of the head of the lidar (in case of rotating lidar).
 
 ---
 
-**Name**
-
-**wb\_lidar\_get\_fov**, **wb\_lidar\_get\_vertical\_fov** - *get the horizontal and vertical field of view of the lidar*
+#### `wb_lidar_get_fov`
+#### `wb_lidar_get_vertical_fov`
 
 [C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
@@ -332,7 +341,9 @@ double wb_lidar_get_fov(WbDeviceTag tag);
 int wb_lidar_get_vertical_fov(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the horizontal and vertical field of view of the lidar*
 
 The `wb_lidar_get_fov` function returns the horizontal field of view of the lidar.
 
@@ -340,9 +351,8 @@ The `wb_lidar_get_vertical_fov` function returns the vertical field of view of t
 
 ---
 
-**Name**
-
-**wb\_lidar\_get\_min\_range**, **wb\_lidar\_get\_max\_range** - *get the minimum and maximum range*
+#### `wb_lidar_get_min_range`
+#### `wb_lidar_get_max_range`
 
 [C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
@@ -353,6 +363,8 @@ double wb_lidar_get_min_range(WbDeviceTag tag);
 double wb_lidar_get_max_range(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the minimum and maximum range*
 
 The `wb_lidar_get_min_range` and `wb_lidar_get_max_range` functions return respectively the minimum and maximum range of the lidar.

--- a/reference/lightsensor.md
+++ b/reference/lightsensor.md
@@ -120,9 +120,10 @@ Finally, if the sensor's `lookupTable` is filled with correct calibration data, 
 
 ### LightSensor Functions
 
-**Name**
-
-**wb\_light\_sensor\_enable**, **wb\_light\_sensor\_disable**, **wb\_light\_sensor\_get\_sampling\_period**, **wb\_light\_sensor\_get\_value** - *enable, disable and read light sensor measurement*
+#### `wb_light_sensor_enable`
+#### `wb_light_sensor_disable`
+#### `wb_light_sensor_get_sampling_period`
+#### `wb_light_sensor_get_value`
 
 [C++](cpp-api.md#cpp_light_sensor) [Java](java-api.md#java_light_sensor) [Python](python-api.md#python_light_sensor) [Matlab](matlab-api.md#matlab_light_sensor) [ROS](ros-api.md)
 
@@ -135,7 +136,9 @@ int wb_light_sensor_get_sampling_period(WbDeviceTag tag);
 double wb_light_sensor_get_value(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable, disable and read light sensor measurement*
 
 The `wb_light_sensor_enable` function enables light sensor measurements.
 The provided `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.

--- a/reference/lightsensor.md
+++ b/reference/lightsensor.md
@@ -124,7 +124,7 @@ Finally, if the sensor's `lookupTable` is filled with correct calibration data, 
 
 **wb\_light\_sensor\_enable**, **wb\_light\_sensor\_disable**, **wb\_light\_sensor\_get\_sampling\_period**, **wb\_light\_sensor\_get\_value** - *enable, disable and read light sensor measurement*
 
-{[C++](cpp-api.md#cpp_light_sensor)}, {[Java](java-api.md#java_light_sensor)}, {[Python](python-api.md#python_light_sensor)}, {[Matlab](matlab-api.md#matlab_light_sensor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_light_sensor) [Java](java-api.md#java_light_sensor) [Python](python-api.md#python_light_sensor) [Matlab](matlab-api.md#matlab_light_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/light_sensor.h>

--- a/reference/motion.md
+++ b/reference/motion.md
@@ -101,7 +101,7 @@ The *reverse mode* can be changed while the motion is playing, in this case, the
 
 By default, the *loop mode* and *reverse mode* of motions are `false`.
 
-##### See also
+##### See Also
 
 [wbu\_motion\_new](#wbu_motion_new)
 

--- a/reference/motion.md
+++ b/reference/motion.md
@@ -1,10 +1,11 @@
 ## Motion
 
-**Name**
+### Motion Functions
 
-**wbu\_motion\_new**, **wbu\_motion\_delete** - *obtaining and releasing a motion file handle*
+#### `wbu_motion_new`
+#### `wbu_motion_delete`
 
-{[C++](cpp-api.md#cpp_motion)}, {[Java](java-api.md#java_motion)}, {[Python](python-api.md#python_motion)}, {[Matlab](matlab-api.md#matlab_motion)}
+[C++](cpp-api.md#cpp_motion) [Java](java-api.md#java_motion) [Python](python-api.md#python_motion) [Matlab](matlab-api.md#matlab_motion)
 
 ```c
 #include <webots/utils/motion.h>
@@ -13,7 +14,9 @@ WbMotionRef wbu_motion_new(const char *filename);
 void wbu_motion_delete(WbMotionRef motion);
 ```
 
-**Description**
+##### Description
+
+*obtaining and releasing a motion file handle*
 
 The `wbu_motion_new` function allows to read a motion file specified by the `filename` parameter.
 The `filename` can be specified either with an absolute path or a path relative to the controller directory.
@@ -37,17 +40,18 @@ if (! walk->isValid()) {
 }
 ```
 
-**See also**
+##### See Also
 
 [wbu\_motion\_play](#wbu_motion_play)
 
 ---
 
-**Name**
+#### `wbu_motion_play`
+#### `wbu_motion_stop`
+#### `wbu_motion_set_loop`
+#### `wbu_motion_set_reverse`
 
-**wbu\_motion\_play**, **wbu\_motion\_stop**, **wbu\_motion\_set\_loop**, **wbu\_motion\_set\_reverse** - *Controlling motion files playback*
-
-{[C++](cpp-api.md#cpp_motion)}, {[Java](java-api.md#java_motion)}, {[Python](python-api.md#python_motion)}, {[Matlab](matlab-api.md#matlab_motion)}
+[C++](cpp-api.md#cpp_motion) [Java](java-api.md#java_motion) [Python](python-api.md#python_motion) [Matlab](matlab-api.md#matlab_motion)
 
 ```c
 #include <webots/utils/motion.h>
@@ -58,7 +62,9 @@ void wbu_motion_set_loop(WbMotionRef motion, bool loop);
 void wbu_motion_set_reverse(WbMotionRefmotion, bool reverse);
 ```
 
-**Description**
+##### Description
+
+*Controlling motion files playback*
 
 The `wbu_motion_play` function starts the playback of the specified motion.
 This function registers the motion to the playback system, but the effective playback happens in the background and is activated as a side effect of calling the `wb_robot_step` function.
@@ -95,17 +101,18 @@ The *reverse mode* can be changed while the motion is playing, in this case, the
 
 By default, the *loop mode* and *reverse mode* of motions are `false`.
 
-**See also**
+##### See also
 
 [wbu\_motion\_new](#wbu_motion_new)
 
 ---
 
-**Name**
+#### `wbu_motion_is_over`
+#### `wbu_motion_get_duration`
+#### `wbu_motion_get_time`
+#### `wbu_motion_set_time`
 
-**wbu\_motion\_is\_over**, **wbu\_motion\_get\_duration**, **wbu\_motion\_get\_time**, **wbu\_motion\_set\_time** - *controlling the playback position*
-
-{[C++](cpp-api.md#cpp_motion)}, {[Java](java-api.md#java_motion)}, {[Python](python-api.md#python_motion)}, {[Matlab](matlab-api.md#matlab_motion)}
+[C++](cpp-api.md#cpp_motion) [Java](java-api.md#java_motion) [Python](python-api.md#python_motion) [Matlab](matlab-api.md#matlab_motion)
 
 ```c
 #include <webots/utils/motion.h>
@@ -116,7 +123,9 @@ int wbu_motion_get_time(WbMotionRef motion, bool loop);
 void wbu_motion_set_time(WbMotionRefmotion, int t);
 ```
 
-**Description**
+##### Description
+
+*controlling the playback position*
 
 The `wbu_motion_is_over` function returns `true` when the playback position has reached the end of the motion file.
 That is when the last pose has been sent to the [Motor](motor.md) nodes using the `wb_motor_set_position` function.
@@ -135,6 +144,6 @@ Note that, the time position can be changed whether the motion is playing or sto
 The minimum value is 0 (beginning of the motion), and the maximum value is the value returned by the `wbu_motion_get_duration` function (end of the motion).
 The time position is expressed in milliseconds.
 
-**See also**
+##### See Also
 
 [wbu\_motion\_play](#wbu_motion_play)

--- a/reference/motor.md
+++ b/reference/motor.md
@@ -219,9 +219,22 @@ If a more specific or accurate model is needed, it can be implemented in the rob
 
 ### Motor Functions
 
-**Name**
-
-**wb\_motor\_set\_position**, **wb\_motor\_set\_velocity**, **wb\_motor\_set\_acceleration**, **wb\_motor\_set\_available\_force**, **wb\_motor\_set\_available\_torque**, **wb\_motor\_set\_control\_pid**, **wb\_motor\_get\_target\_position**, **wb\_motor\_get\_min\_position**, **wb\_motor\_get\_max\_position**, **wb\_motor\_get\_velocity**, **wb\_motor\_get\_max\_velocty**, **wb\_motor\_get\_acceleration**, **wb\_motor\_get\_available\_force**, **wb\_motor\_get\_max\_force**, **wb\_motor\_get\_available\_torque**, **wb\_motor\_get\_max\_torque** - *change the parameters of the PID-controller*
+#### `wb_motor_set_position`
+#### `wb_motor_set_velocity`
+#### `wb_motor_set_acceleration`
+#### `wb_motor_set_available_force`
+#### `wb_motor_set_available_torque`
+#### `wb_motor_set_control_pid`
+#### `wb_motor_get_target_position`
+#### `wb_motor_get_min_position`
+#### `wb_motor_get_max_position`
+#### `wb_motor_get_velocity`
+#### `wb_motor_get_max_velocty`
+#### `wb_motor_get_acceleration`
+#### `wb_motor_get_available_force`
+#### `wb_motor_get_max_force`
+#### `wb_motor_get_available_torque`
+#### `wb_motor_get_max_torque`
 
 [C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
@@ -246,7 +259,9 @@ double wb_motor_get_available_torque(WbDeviceTag tag);
 double wb_motor_get_max_torque(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*change the parameters of the PID-controller*
 
 The `wb_motor_set_position` function specifies a new target position that the PID-controller will attempt to reach using the current velocity, acceleration and motor torque/force parameters.
 This function returns immediately (asynchronous) while the actual motion is carried out in the background by Webots.
@@ -322,9 +337,14 @@ The `wb_motor_get_[min|max]_position` functions allow to get the values of respe
 
 ---
 
-**Name**
-
-**wb\_motor\_enable\_force\_feedback**, **wb\_motor\_get\_force\_feedback**, **wb\_motor\_get\_force\_feedback\_sampling\_period**, **wb\_motor\_disable\_force\_feedback**, **wb\_motor\_enable\_torque\_feedback**, **wb\_motor\_get\_torque\_feedback**, **wb\_motor\_get\_torque\_feedback\_sampling\_period**, **wb\_motor\_disable\_torque\_feedback** - *get the motor force or torque currently used by a motor*
+#### `wb_motor_enable_force_feedback`
+#### `wb_motor_get_force_feedback`
+#### `wb_motor_get_force_feedback_sampling_period`
+#### `wb_motor_disable_force_feedback`
+#### `wb_motor_enable_torque_feedback`
+#### `wb_motor_get_torque_feedback`
+#### `wb_motor_get_torque_feedback_sampling_period`
+#### `wb_motor_disable_torque_feedback`
 
 [C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
@@ -341,7 +361,9 @@ int wb_motor_get_torque_feedback_sampling_period(WbDeviceTag tag);
 double wb_motor_get_torque_feedback(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the motor force or torque currently used by a motor*
 
 The `wb_motor_enable_force_feedback` (resp. `wb_motor_enable_torque_feedback`) function activates force (resp. torque) feedback measurements for the specified motor.
 The result must be retrieved with the `wb_motor_get_force_feedback` (resp. `wb_motor_get_torque_feedback`) function.
@@ -376,9 +398,8 @@ The `wb_motor_get_force_feedback_sampling_period` (resp. `wb_motor_get_torque_fe
 
 ---
 
-**Name**
-
-**wb\_motor\_set\_force**, **wb\_motor\_set\_torque** - *direct force or torque control*
+#### `wb_motor_set_force`
+#### `wb_motor_set_torque`
 
 [C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
@@ -389,7 +410,9 @@ void wb_motor_set_force(WbDeviceTag tag, double force);
 void wb_motor_set_torque(WbDeviceTag tag, double torque);
 ```
 
-**Description**
+##### Description
+
+*direct force or torque control*
 
 As an alternative to the PID-controller, the `wb_motor_set_force` (resp. `wb_motor_set_torque`) function allows the user to directly specify the amount of force (resp. torque) that must be applied by a motor.
 This function bypasses the PID-controller and ODE joint motors; it adds the force to the physics simulation directly.
@@ -410,9 +433,7 @@ The example in "projects/samples/howto/worlds/force\_control.wbt" demonstrates t
 
 ---
 
-**Name**
-
-**wb\_motor\_get\_type** - *get the motor type*
+#### `wb_motor_get_type`
 
 [C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
@@ -422,7 +443,9 @@ The example in "projects/samples/howto/worlds/force\_control.wbt" demonstrates t
 int wb_motor_get_type(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the motor type*
 
 This function allows the user to retrieve the motor type defined by the `type` field.
 If the value of the `type` field is "linear", this function returns WB\_LINEAR, and otherwise it returns WB\_ANGULAR.

--- a/reference/motor.md
+++ b/reference/motor.md
@@ -223,7 +223,7 @@ If a more specific or accurate model is needed, it can be implemented in the rob
 
 **wb\_motor\_set\_position**, **wb\_motor\_set\_velocity**, **wb\_motor\_set\_acceleration**, **wb\_motor\_set\_available\_force**, **wb\_motor\_set\_available\_torque**, **wb\_motor\_set\_control\_pid**, **wb\_motor\_get\_target\_position**, **wb\_motor\_get\_min\_position**, **wb\_motor\_get\_max\_position**, **wb\_motor\_get\_velocity**, **wb\_motor\_get\_max\_velocty**, **wb\_motor\_get\_acceleration**, **wb\_motor\_get\_available\_force**, **wb\_motor\_get\_max\_force**, **wb\_motor\_get\_available\_torque**, **wb\_motor\_get\_max\_torque** - *change the parameters of the PID-controller*
 
-{[C++](cpp-api.md#cpp_motor)}, {[Java](java-api.md#java_motor)}, {[Python](python-api.md#python_motor)}, {[Matlab](matlab-api.md#matlab_motor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
 ```c
 #include <webots/motor.h>
@@ -326,7 +326,7 @@ The `wb_motor_get_[min|max]_position` functions allow to get the values of respe
 
 **wb\_motor\_enable\_force\_feedback**, **wb\_motor\_get\_force\_feedback**, **wb\_motor\_get\_force\_feedback\_sampling\_period**, **wb\_motor\_disable\_force\_feedback**, **wb\_motor\_enable\_torque\_feedback**, **wb\_motor\_get\_torque\_feedback**, **wb\_motor\_get\_torque\_feedback\_sampling\_period**, **wb\_motor\_disable\_torque\_feedback** - *get the motor force or torque currently used by a motor*
 
-{[C++](cpp-api.md#cpp_motor)}, {[Java](java-api.md#java_motor)}, {[Python](python-api.md#python_motor)}, {[Matlab](matlab-api.md#matlab_motor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
 ```c
 #include <webots/motor.h>
@@ -380,7 +380,7 @@ The `wb_motor_get_force_feedback_sampling_period` (resp. `wb_motor_get_torque_fe
 
 **wb\_motor\_set\_force**, **wb\_motor\_set\_torque** - *direct force or torque control*
 
-{[C++](cpp-api.md#cpp_motor)}, {[Java](java-api.md#java_motor)}, {[Python](python-api.md#python_motor)}, {[Matlab](matlab-api.md#matlab_motor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
 ```c
 #include <webots/motor.h>
@@ -414,7 +414,7 @@ The example in "projects/samples/howto/worlds/force\_control.wbt" demonstrates t
 
 **wb\_motor\_get\_type** - *get the motor type*
 
-{[C++](cpp-api.md#cpp_motor)}, {[Java](java-api.md#java_motor)}, {[Python](python-api.md#python_motor)}, {[Matlab](matlab-api.md#matlab_motor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
 ```c
 #include <webots/motor.h>

--- a/reference/mouse.md
+++ b/reference/mouse.md
@@ -35,9 +35,10 @@ These values may be `NaN` if not applicable, for example when the mouse is point
 
 ### Mouse Functions
 
-**Name**
-
-**wb\_mouse\_enable**, **wb\_mouse\_disable**, **wb\_mouse\_get\_sampling\_period**, **wb\_mouse\_get\_key** - *mouse reading function*
+#### `wb_mouse_enable`
+#### `wb_mouse_disable`
+#### `wb_mouse_get_sampling_period`
+#### `wb_mouse_get_key`
 
 [C++](cpp-api.md#cpp_mouse) [Java](java-api.md#java_mouse) [Python](python-api.md#python_mouse) [Matlab](matlab-api.md#matlab_mouse) [ROS](ros-api.md)
 
@@ -50,7 +51,9 @@ int wb_mouse_get_sampling_period();
 WbMouseState wb_mouse_get_state();
 ```
 
-**Description**
+##### Description
+
+*mouse reading function*
 
 The state of the computer mouse can be read from a controller program while the simulation is running by using the above functions.
 Firstly it is necessary to enable mouse input by calling the `wb_mouse_enable` function.

--- a/reference/mouse.md
+++ b/reference/mouse.md
@@ -39,7 +39,7 @@ These values may be `NaN` if not applicable, for example when the mouse is point
 
 **wb\_mouse\_enable**, **wb\_mouse\_disable**, **wb\_mouse\_get\_sampling\_period**, **wb\_mouse\_get\_key** - *mouse reading function*
 
-{[C++](cpp-api.md#cpp_mouse)}, {[Java](java-api.md#java_mouse)}, {[Python](python-api.md#python_mouse)}, {[Matlab](matlab-api.md#matlab_mouse)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_mouse) [Java](java-api.md#java_mouse) [Python](python-api.md#python_mouse) [Matlab](matlab-api.md#matlab_mouse) [ROS](ros-api.md)
 
 ```c
 #include <webots/mouse.h>

--- a/reference/pen.md
+++ b/reference/pen.md
@@ -63,7 +63,7 @@ It is also switchable from the pen API, using the `wb_pen_write` function.
 
 **wb\_pen\_write** - *enable or disable pen writing*
 
-{[C++](cpp-api.md#cpp_pen)}, {[Java](java-api.md#java_pen)}, {[Python](python-api.md#python_pen)}, {[Matlab](matlab-api.md#matlab_pen)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_pen) [Java](java-api.md#java_pen) [Python](python-api.md#python_pen) [Matlab](matlab-api.md#matlab_pen) [ROS](ros-api.md)
 
 ```c
 #include <webots/pen.h>
@@ -82,7 +82,7 @@ If the `write` parameter is *true*, the specified `tag` device will write; if `w
 
 **wb\_pen\_set\_ink\_color** - *change the color of a pen's ink*
 
-{[C++](cpp-api.md#cpp_pen)}, {[Java](java-api.md#java_pen)}, {[Python](python-api.md#python_pen)}, {[Matlab](matlab-api.md#matlab_pen)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_pen) [Java](java-api.md#java_pen) [Python](python-api.md#python_pen) [Matlab](matlab-api.md#matlab_pen) [ROS](ros-api.md)
 
 ```c
 #include <webots/pen.h>

--- a/reference/pen.md
+++ b/reference/pen.md
@@ -59,9 +59,7 @@ It is also switchable from the pen API, using the `wb_pen_write` function.
 
 ### Pen Functions
 
-**Name**
-
-**wb\_pen\_write** - *enable or disable pen writing*
+#### `wb_pen_write`
 
 [C++](cpp-api.md#cpp_pen) [Java](java-api.md#java_pen) [Python](python-api.md#python_pen) [Matlab](matlab-api.md#matlab_pen) [ROS](ros-api.md)
 
@@ -71,16 +69,16 @@ It is also switchable from the pen API, using the `wb_pen_write` function.
 void wb_pen_write(WbDeviceTag tag, bool write);
 ```
 
-**Description**
+##### Description
+
+*enable or disable pen writing*
 
 The `wb_pen_write` function allows the user to switch a pen device on or off to disable or enable writing.
 If the `write` parameter is *true*, the specified `tag` device will write; if `write` is *false*, it won't.
 
 ---
 
-**Name**
-
-**wb\_pen\_set\_ink\_color** - *change the color of a pen's ink*
+#### `wb_pen_set_ink_color`
 
 [C++](cpp-api.md#cpp_pen) [Java](java-api.md#java_pen) [Python](python-api.md#python_pen) [Matlab](matlab-api.md#matlab_pen) [ROS](ros-api.md)
 
@@ -90,13 +88,15 @@ If the `write` parameter is *true*, the specified `tag` device will write; if `w
 void wb_pen_set_ink_color(WbDeviceTag tag, int color, double density);
 ```
 
-**Description**
+##### Description
+
+*change the color of a pen's ink*
 
 The `wb_pen_set_ink_color` function changes the current ink color of the specified `tag` device.
 The `color` is a 32 bit integer value which defines the new color of the ink in the 0xRRGGBB hexadecimal format (i.e., 0x000000 is black, 0xFF0000 is red, 0x00FF00 is green, 0x0000FF is blue, 0xFFA500 is orange, 0x808080 is gray 0xFFFFFF is white, etc.).
 The `density` parameter defines the ink density, with 0 meaning transparent ink and 1 meaning completely opaque ink.
 
-**Example**
+##### Example
 
 ```c
 wb_pen_set_ink_color(pen,0xF01010,0.9);

--- a/reference/positionsensor.md
+++ b/reference/positionsensor.md
@@ -26,7 +26,7 @@ This field accepts any value in the interval (0.0, inf).
 
 **wb\_position\_sensor\_enable**, **wb\_position\_sensor\_disable**, **wb\_position\_sensor\_get\_sampling\_period**, **wb\_position\_sensor\_get\_value**, **wb\_position\_sensor\_get\_type** - *enable, disable and read position sensor measurement*
 
-{[C++](cpp-api.md#cpp_position_sensor)}, {[Java](java-api.md#java_position_sensor)}, {[Python](python-api.md#python_position_sensor)}, {[Matlab](matlab-api.md#matlab_position_sensor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_position_sensor) [Java](java-api.md#java_position_sensor) [Python](python-api.md#python_position_sensor) [Matlab](matlab-api.md#matlab_position_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/position_sensor.h>

--- a/reference/positionsensor.md
+++ b/reference/positionsensor.md
@@ -22,9 +22,11 @@ This field accepts any value in the interval (0.0, inf).
 
 ### PositionSensor Functions
 
-**Name**
-
-**wb\_position\_sensor\_enable**, **wb\_position\_sensor\_disable**, **wb\_position\_sensor\_get\_sampling\_period**, **wb\_position\_sensor\_get\_value**, **wb\_position\_sensor\_get\_type** - *enable, disable and read position sensor measurement*
+#### `wb_position_sensor_enable`
+#### `wb_position_sensor_disable`
+#### `wb_position_sensor_get_sampling_period`
+#### `wb_position_sensor_get_value`
+#### `wb_position_sensor_get_type`
 
 [C++](cpp-api.md#cpp_position_sensor) [Java](java-api.md#java_position_sensor) [Python](python-api.md#python_position_sensor) [Matlab](matlab-api.md#matlab_position_sensor) [ROS](ros-api.md)
 
@@ -38,7 +40,9 @@ double wb_position_sensor_get_value(WbDeviceTag tag);
 int wb_position_sensor_get_type(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable, disable and read position sensor measurement*
 
 The `wb_position_sensor_enable` function enables measurements of the joint position.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.

--- a/reference/radar.md
+++ b/reference/radar.md
@@ -130,9 +130,9 @@ The power returned by the target is computed using the following formulas:
 
 ### Radar Functions
 
-**Name**
-
-**wb\_radar\_enable**, **wb\_radar\_disable**, **wb\_radar\_get\_sampling\_period** - *enable and disable radar updates*
+#### `wb_radar_enable`
+#### `wb_radar_disable`
+#### `wb_radar_get_sampling_period`
 
 [C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
@@ -144,7 +144,9 @@ void wb_radar_disable(WbDeviceTag tag);
 int wb_radar_get_sampling_period(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable and disable radar updates*
 
 The `wb_radar_enable` function allows the user to enable radar updates.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.
@@ -156,9 +158,8 @@ The `wb_radar_get_sampling_period` function returns the period given into the `w
 
 ---
 
-**Name**
-
-**wb\_radar\_get\_min\_range**, **wb\_radar\_get\_max\_range** - *get the minimum and maximum range of the radar*
+#### `wb_radar_get_min_range`
+#### `wb_radar_get_max_range`
 
 [C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
@@ -169,15 +170,16 @@ double wb_radar_get_min_range(WbDeviceTag tag);
 double wb_radar_get_max_range(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the minimum and maximum range of the radar*
 
 These functions allow the controller to get the value of the minimum and maximum range of the radar.
 
 ---
 
-**Name**
-
-**wb\_radar\_get\_horizontal\_fov**, **wb\_radar\_get\_vertical\_fov** - *get the horizontal and vertical field of view of the radar*
+#### `wb_radar_get_horizontal_fov`
+#### `wb_radar_get_vertical_fov`
 
 [C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
@@ -188,15 +190,15 @@ double wb_radar_get_horizontal_fov(WbDeviceTag tag);
 double wb_radar_get_vertical_fov(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the horizontal and vertical field of view of the radar*
 
 These functions allow the controller to get the value of the horizontal and vertical field of view of the radar.
 
 ---
 
-**Name**
-
-**wb\_radar\_get\_number\_of\_targets** - *get the current number of targets*
+#### `wb_radar_get_number_of_targets`
 
 [C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
@@ -206,15 +208,15 @@ These functions allow the controller to get the value of the horizontal and vert
 int wb_radar_get_number_of_targets(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the current number of targets*
 
 This function allows the controller to get the number of targets currently seen by the radar.
 
 ---
 
-**Name**
-
-**wb\_radar\_get\_targets** - *get the targets array*
+#### `wb_radar_get_targets`
 
 [C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
@@ -224,7 +226,9 @@ This function allows the controller to get the number of targets currently seen 
 const WbRadarTarget * wb_radar_get_targets(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the targets array*
 
 This function returns the targets array.
 The size of the array can be get using the function `wb_radar_get_number_of_targets`.

--- a/reference/radar.md
+++ b/reference/radar.md
@@ -134,7 +134,7 @@ The power returned by the target is computed using the following formulas:
 
 **wb\_radar\_enable**, **wb\_radar\_disable**, **wb\_radar\_get\_sampling\_period** - *enable and disable radar updates*
 
-{[C++](cpp-api.md#cpp_radar)}, {[Java](java-api.md#java_radar)}, {[Python](python-api.md#python_radar)}, {[Matlab](matlab-api.md#matlab_radar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
 ```c
 #include <webots/radar.h>
@@ -160,7 +160,7 @@ The `wb_radar_get_sampling_period` function returns the period given into the `w
 
 **wb\_radar\_get\_min\_range**, **wb\_radar\_get\_max\_range** - *get the minimum and maximum range of the radar*
 
-{[C++](cpp-api.md#cpp_radar)}, {[Java](java-api.md#java_radar)}, {[Python](python-api.md#python_radar)}, {[Matlab](matlab-api.md#matlab_radar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
 ```c
 #include <webots/radar.h>
@@ -179,7 +179,7 @@ These functions allow the controller to get the value of the minimum and maximum
 
 **wb\_radar\_get\_horizontal\_fov**, **wb\_radar\_get\_vertical\_fov** - *get the horizontal and vertical field of view of the radar*
 
-{[C++](cpp-api.md#cpp_radar)}, {[Java](java-api.md#java_radar)}, {[Python](python-api.md#python_radar)}, {[Matlab](matlab-api.md#matlab_radar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
 ```c
 #include <webots/radar.h>
@@ -198,7 +198,7 @@ These functions allow the controller to get the value of the horizontal and vert
 
 **wb\_radar\_get\_number\_of\_targets** - *get the current number of targets*
 
-{[C++](cpp-api.md#cpp_radar)}, {[Java](java-api.md#java_radar)}, {[Python](python-api.md#python_radar)}, {[Matlab](matlab-api.md#matlab_radar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
 ```c
 #include <webots/radar.h>
@@ -216,7 +216,7 @@ This function allows the controller to get the number of targets currently seen 
 
 **wb\_radar\_get\_targets** - *get the targets array*
 
-{[C++](cpp-api.md#cpp_radar)}, {[Java](java-api.md#java_radar)}, {[Python](python-api.md#python_radar)}, {[Matlab](matlab-api.md#matlab_radar)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
 ```c
 #include <webots/radar.h>

--- a/reference/rangefinder.md
+++ b/reference/rangefinder.md
@@ -96,9 +96,9 @@ Then, after closing the window, the overlay will be automatically restored.
 
 ### RangeFinder Functions
 
-**Name**
-
-**wb\_range\_finder\_enable**, **wb\_range\_finder\_disable**, **wb\_range\_finder\_get\_sampling\_period** - *enable and disable range-finder updates*
+#### `wb_range_finder_enable`
+#### `wb_range_finder_disable`
+#### `wb_range_finder_get_sampling_period`
 
 [C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
@@ -110,7 +110,9 @@ void wb_range_finder_disable(WbDeviceTag tag);
 int wb_range_finder_get_sampling_period(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable and disable range-finder updates*
 
 The `wb_range_finder_enable` function allows the user to enable range-finder updates.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.
@@ -122,9 +124,7 @@ The `wb_range_finder_get_sampling_period` function returns the period given into
 
 ---
 
-**Name**
-
-**wb\_range\_finder\_get\_fov** - *get field of view for a range-finder*
+#### `wb_range_finder_get_fov`
 
 [C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
@@ -134,15 +134,16 @@ The `wb_range_finder_get_sampling_period` function returns the period given into
 double wb_range_finder_get_fov(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get field of view for a range-finder*
 
 These functions allow the controller to get the value of the field of view (fov) of a range-finder.
 
 ---
 
-**Name**
-
-**wb\_range\_finder\_get\_width**, **wb\_range\_finder\_get\_height** - *get the size of the range-finder image*
+#### `wb_range_finder_get_width`
+#### `wb_range_finder_get_height`
 
 [C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
@@ -153,15 +154,16 @@ int wb_range_finder_get_width(WbDeviceTag tag);
 int wb_range_finder_get_height(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the size of the range-finder image*
 
 These functions return the width and height of a range-finder image as defined in the corresponding [RangeFinder](#rangefinder) node.
 
 ---
 
-**Name**
-
-**wb\_range\_finder\_get\_min\_range**, **wb\_range\_finder\_get\_max\_range** - *get the minimum and maximum range of the range-finder device*
+#### `wb_range_finder_get_min_range`
+#### `wb_range_finder_get_max_range`
 
 [C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
@@ -172,15 +174,16 @@ double wb_range_finder_get_min_range(WbDeviceTag tag);
 double wb_range_finder_get_max_range(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the minimum and maximum range of the range-finder device*
 
 These functions return the minRange and maxRange parameters of a range-finder device as defined in the corresponding [RangeFinder](#rangefinder) node.
 
 ---
 
-**Name**
-
-**wb\_range\_finder\_get\_range\_image**, **wb\_range\_finder\_image\_get\_depth** - *get the range image and range data from a range-finder*
+#### `wb_range_finder_get_range_image`
+#### `wb_range_finder_image_get_depth`
 
 [C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
@@ -191,7 +194,9 @@ const float *wb_range_finder_get_range_image(WbDeviceTag tag);
 float wb_range_finder_image_get_depth(const float *range_image, int width, int x, int y);
 ```
 
-**Description**
+##### Description
+
+*get the range image and range data from a range-finder*
 
 The `wb_range_finder_get_range_image` macro allows the user to read the contents of the last range image grabbed by a range-finder.
 The range image is computed using the depth buffer produced by the OpenGL rendering.
@@ -219,9 +224,7 @@ Their content are identical but their handling is of course different.
 
 ---
 
-**Name**
-
-**wb\_range\_finder\_save\_image** - *save a range-finder image in PNG, JPEG or TIFF format*
+#### `wb_range_finder_save_image`
 
 [C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
@@ -231,7 +234,9 @@ Their content are identical but their handling is of course different.
 int wb_range_finder_save_image(WbDeviceTag tag, const char *filename, int quality);
 ```
 
-**Description**
+##### Description
+
+*save a range-finder image in PNG, JPEG or TIFF format*
 
 The `wb_range_finder_save_image` function allows the user to save a `tag` image which was previously obtained with the `wb_range_finder_get_image` function.
 The image can be saved in a file using the PNG, JPEG, or TIFF format.

--- a/reference/rangefinder.md
+++ b/reference/rangefinder.md
@@ -100,7 +100,7 @@ Then, after closing the window, the overlay will be automatically restored.
 
 **wb\_range\_finder\_enable**, **wb\_range\_finder\_disable**, **wb\_range\_finder\_get\_sampling\_period** - *enable and disable range-finder updates*
 
-{[C++](cpp-api.md#cpp_range_finder)}, {[Java](java-api.md#java_range_finder)}, {[Python](python-api.md#python_range_finder)}, {[Matlab](matlab-api.md#matlab_range_finder)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>
@@ -126,7 +126,7 @@ The `wb_range_finder_get_sampling_period` function returns the period given into
 
 **wb\_range\_finder\_get\_fov** - *get field of view for a range-finder*
 
-{[C++](cpp-api.md#cpp_range_finder)}, {[Java](java-api.md#java_range_finder)}, {[Python](python-api.md#python_range_finder)}, {[Matlab](matlab-api.md#matlab_range_finder)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>
@@ -144,7 +144,7 @@ These functions allow the controller to get the value of the field of view (fov)
 
 **wb\_range\_finder\_get\_width**, **wb\_range\_finder\_get\_height** - *get the size of the range-finder image*
 
-{[C++](cpp-api.md#cpp_range_finder)}, {[Java](java-api.md#java_range_finder)}, {[Python](python-api.md#python_range_finder)}, {[Matlab](matlab-api.md#matlab_range_finder)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>
@@ -163,7 +163,7 @@ These functions return the width and height of a range-finder image as defined i
 
 **wb\_range\_finder\_get\_min\_range**, **wb\_range\_finder\_get\_max\_range** - *get the minimum and maximum range of the range-finder device*
 
-{[C++](cpp-api.md#cpp_range_finder)}, {[Java](java-api.md#java_range_finder)}, {[Python](python-api.md#python_range_finder)}, {[Matlab](matlab-api.md#matlab_range_finder)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>
@@ -182,7 +182,7 @@ These functions return the minRange and maxRange parameters of a range-finder de
 
 **wb\_range\_finder\_get\_range\_image**, **wb\_range\_finder\_image\_get\_depth** - *get the range image and range data from a range-finder*
 
-{[C++](cpp-api.md#cpp_range_finder)}, {[Java](java-api.md#java_range_finder)}, {[Python](python-api.md#python_range_finder)}, {[Matlab](matlab-api.md#matlab_range_finder)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>
@@ -223,7 +223,7 @@ Their content are identical but their handling is of course different.
 
 **wb\_range\_finder\_save\_image** - *save a range-finder image in PNG, JPEG or TIFF format*
 
-{[C++](cpp-api.md#cpp_range_finder)}, {[Java](java-api.md#java_range_finder)}, {[Python](python-api.md#python_range_finder)}, {[Matlab](matlab-api.md#matlab_range_finder)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>

--- a/reference/receiver.md
+++ b/reference/receiver.md
@@ -63,9 +63,9 @@ The noise is not dependent on the distance between emitter-receiver.
 
 ### Receiver Functions
 
-**Name**
-
-**wb\_receiver\_enable**, **wb\_receiver\_disable**, **wb\_receiver\_get\_sampling\_period** - *enable and disable receiver*
+#### `wb_receiver_enable`
+#### `wb_receiver_disable`
+#### `wb_receiver_get_sampling_period`
 
 [C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
@@ -77,7 +77,9 @@ void wb_receiver_disable(WbDeviceTag tag);
 int wb_receiver_get_sampling_period(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable and disable receiver*
 
 The `wb_receiver_enable` function starts the receiver listening for incoming data packets.
 Data reception is activated in the background of the controller's loop at a rate of once every `sampling_period` (expressed in milliseconds).
@@ -93,9 +95,8 @@ The `wb_receiver_get_sampling_period` function returns the period given into the
 
 ---
 
-**Name**
-
-**wb\_receiver\_get\_queue\_length**, **wb\_receiver\_next\_packet** - *check for the presence of data packets in the receivers queue*
+#### `wb_receiver_get_queue_length`
+#### `wb_receiver_next_packet`
 
 [C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
@@ -106,7 +107,9 @@ int wb_receiver_get_queue_length(WbDeviceTag tag);
 void wb_receiver_next_packet(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*check for the presence of data packets in the receivers queue*
 
 The `wb_receiver_get_queue_length` function returns the number of data packets currently present in the receiver's queue (see [this figure](#receivers-packet-queue)).
 
@@ -154,9 +157,8 @@ Making assumptions based on timing will result in code that is not robust.
 
 ---
 
-**Name**
-
-**wb\_receiver\_get\_data**, **wb\_receiver\_get\_data\_size** - *get data and size of the current packet*
+#### `wb_receiver_get_data`
+#### `wb_receiver_get_data_size`
 
 [C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
@@ -167,7 +169,9 @@ const void *wb_receiver_get_data(WbDeviceTag tag);
 int wb_receiver_get_data_size(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get data and size of the current packet*
 
 The `wb_receiver_get_data` function returns the data of the packet at the head of the reception queue (see [this figure](#receivers-packet-queue)).
 The returned data pointer is only valid until the next call to the `wb_receiver_next_packet` function.
@@ -235,9 +239,8 @@ More sophisticated data typed must be accessed explicitly using `setdatatype` an
 
 ---
 
-**Name**
-
-**wb\_receiver\_get\_signal\_strength**, **wb\_receiver\_get\_emitter\_direction** - *get signal strength and emitter direction*
+#### `wb_receiver_get_signal_strength`
+#### `wb_receiver_get_emitter_direction`
 
 [C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
@@ -248,7 +251,9 @@ double wb_receiver_get_signal_strength(WbDeviceTag tag);
 const double *wb_receiver_get_emitter_direction(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get signal strength and emitter direction*
 
 The `wb_receiver_get_signal_strength` function operates on the head packet in the receiver's queue (see [this figure](#receivers-packet-queue)).
 It returns the simulated signal strength at the time the packet was transmitted.
@@ -270,9 +275,8 @@ It is illegal to call this function if the receiver's queue is empty (i.e. when 
 
 ---
 
-**Name**
-
-**wb\_receiver\_set\_channel**, **wb\_receiver\_get\_channel** - *set and get the receiver's channel.*
+#### `wb_receiver_set_channel`
+#### `wb_receiver_get_channel`
 
 [C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
@@ -283,7 +287,9 @@ void wb_receiver_set_channel(WbDeviceTag tag, int channel);
 int wb_receiver_get_channel(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*set and get the receiver's channel.*
 
 The `wb_receiver_set_channel` function allows a receiver to change its reception channel.
 It modifies the `channel` field of the corresponding [Receiver](#receiver) node.

--- a/reference/receiver.md
+++ b/reference/receiver.md
@@ -67,7 +67,7 @@ The noise is not dependent on the distance between emitter-receiver.
 
 **wb\_receiver\_enable**, **wb\_receiver\_disable**, **wb\_receiver\_get\_sampling\_period** - *enable and disable receiver*
 
-{[C++](cpp-api.md#cpp_receiver)}, {[Java](java-api.md#java_receiver)}, {[Python](python-api.md#python_receiver)}, {[Matlab](matlab-api.md#matlab_receiver)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
 ```c
 #include <webots/receiver.h>
@@ -97,7 +97,7 @@ The `wb_receiver_get_sampling_period` function returns the period given into the
 
 **wb\_receiver\_get\_queue\_length**, **wb\_receiver\_next\_packet** - *check for the presence of data packets in the receivers queue*
 
-{[C++](cpp-api.md#cpp_receiver)}, {[Java](java-api.md#java_receiver)}, {[Python](python-api.md#python_receiver)}, {[Matlab](matlab-api.md#matlab_receiver)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
 ```c
 #include <webots/receiver.h>
@@ -158,7 +158,7 @@ Making assumptions based on timing will result in code that is not robust.
 
 **wb\_receiver\_get\_data**, **wb\_receiver\_get\_data\_size** - *get data and size of the current packet*
 
-{[C++](cpp-api.md#cpp_receiver)}, {[Java](java-api.md#java_receiver)}, {[Python](python-api.md#python_receiver)}, {[Matlab](matlab-api.md#matlab_receiver)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
 ```c
 #include <webots/receiver.h>
@@ -239,7 +239,7 @@ More sophisticated data typed must be accessed explicitly using `setdatatype` an
 
 **wb\_receiver\_get\_signal\_strength**, **wb\_receiver\_get\_emitter\_direction** - *get signal strength and emitter direction*
 
-{[C++](cpp-api.md#cpp_receiver)}, {[Java](java-api.md#java_receiver)}, {[Python](python-api.md#python_receiver)}, {[Matlab](matlab-api.md#matlab_receiver)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
 ```c
 #include <webots/receiver.h>
@@ -274,7 +274,7 @@ It is illegal to call this function if the receiver's queue is empty (i.e. when 
 
 **wb\_receiver\_set\_channel**, **wb\_receiver\_get\_channel** - *set and get the receiver's channel.*
 
-{[C++](cpp-api.md#cpp_receiver)}, {[Java](java-api.md#java_receiver)}, {[Python](python-api.md#python_receiver)}, {[Matlab](matlab-api.md#matlab_receiver)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
 ```c
 #include <webots/receiver.h>

--- a/reference/robot.md
+++ b/reference/robot.md
@@ -112,9 +112,9 @@ Asynchronous controllers may also be recommended for networked simulations invol
 
 ### Robot Functions
 
-**Name**
-
-**wb\_robot\_step**, **wb\_robot\_init**, **wb\_robot\_cleanup** - *controller step, initialization and cleanup functions*
+#### `wb_robot_step`
+#### `wb_robot_init`
+#### `wb_robot_cleanup`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -126,7 +126,9 @@ void wb_robot_init();
 void wb_robot_cleanup();
 ```
 
-**Description**
+##### Description
+
+*controller step, initialization and cleanup functions*
 
 The `wb_robot_step` function is crucial and must be used in every controller.
 This function synchronizes the sensor and actuator data between Webots and the controllers.
@@ -212,11 +214,9 @@ int main() {
 
 ---
 
-**Name**
+#### `wb_robot_get_device`
 
-**wb\_robot\_get\_device** - *get a unique identifier to a device*
-
-{[Matlab](matlab-api.md#matlab_robot)}
+[Matlab](matlab-api.md#matlab_robot)
 
 ```c
 #include <webots/robot.h>
@@ -224,7 +224,9 @@ int main() {
 WbDeviceTag wb_robot_get_device(const char *name);
 ```
 
-**Description**
+##### Description
+
+*get a unique identifier to a device*
 
 This function returns a unique identifier for a device corresponding to a specified `name`.
 For example, if a robot contains a [DistanceSensor](distancesensor.md) node whose `name` field is "ds1", the function will return the unique identifier of that device.
@@ -234,17 +236,38 @@ If the specified device is not found, the function returns 0.
 > **Note**: This function is not available in the C++, Java and Python APIs.
 Instead, C++, Java and Python users should use device specific typed methods (see below).
 
-**See also**
+##### See also
 
 [`wb_robot_step`](#wb_robot_step).
 
 ---
 
-**Name**
+#### `Robot::getAccelerometer`
+#### `Robot::getBrake`
+#### `Robot::getCamera`
+#### `Robot::getCompass`
+#### `Robot::getConnector`
+#### `Robot::getDisplay`
+#### `Robot::getDistanceSensor`
+#### `Robot::getEmitter`
+#### `Robot::getGPS`
+#### `Robot::getGyro`
+#### `Robot::getInertialUnit`
+#### `Robot::getJoystick`
+#### `Robot::getKeyboard`
+#### `Robot::getLED`
+#### `Robot::getLidar`
+#### `Robot::getLightSensor`
+#### `Robot::getMotor`
+#### `Robot::getPen`
+#### `Robot::getPositionSensor`
+#### `Robot::getRadar`
+#### `Robot::getRangeFinder`
+#### `Robot::getReceiver`
+#### `Robot::getSpeaker`
+#### `Robot::getTouchSensor`
 
-**Robot::getAccelerometer**, **Robot::getBrake**, **Robot::getCamera**, **Robot::getCompass**, **Robot::getConnector**, **Robot::getDisplay**, **Robot::getDistanceSensor**, **Robot::getEmitter**, **Robot::getGPS**, **Robot::getGyro**, **Robot::getInertialUnit**, **Robot::getJoystick**, **Robot::getKeyboard**, **Robot::getLED**, **Robot::getLidar**, **Robot::getLightSensor**, **Robot::getMotor**, **Robot::getPen**, **Robot::getPositionSensor**, **Robot::getRadar**, **Robot::getRangeFinder**, **Robot::getReceiver**, **Robot::getSpeaker**, **Robot::getTouchSensor** - *get the instance of a robot's device*
-
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot)
 
 ```c
 #include <webots/Robot.hpp>
@@ -275,7 +298,9 @@ Speaker *Robot::getSpeaker(const std::string &name);
 TouchSensor *Robot::getTouchSensor(const std::string &name);
 ```
 
-**Description**
+##### Description
+
+*get the instance of a robot's device*
 
 These functions return a reference to an object corresponding to a specified `name`.
 Depending on the called function, this object can be an instance of a `Device` subclass.
@@ -285,15 +310,13 @@ If the specified device is not found, the function returns `NULL` in C++, `null`
 > **Note**: These functions are not available in the C and MATLAB APIs.
 Instead, C and Matlab users should use [`wb_robot_get_device`](#wb_robot_get_device) function.
 
-**See also**
+##### See also
 
 [`wb_robot_get_device`](#wb_robot_get_device), [`wb_robot_step`](#wb_robot_step).
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_device\_by\_index** - *get the devices by introspection*
+#### `wb_robot_get_device_by_index`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -304,7 +327,9 @@ WbDeviceTag wb_robot_get_device_by_index(int index);
 int wb_robot_get_number_of_devices();
 ```
 
-**Description**
+##### Description
+
+*get the devices by introspection*
 
 These functions allows to get the robot devices by introspection.
 Indeed they allow to get the devices from an internal flat list storing the devices.
@@ -337,9 +362,10 @@ for(i=0; i<n_devices; i++) {
 
 ---
 
-**Name**
-
-**wb\_robot\_battery\_sensor\_enable**, **wb\_robot\_battery\_sensor\_disable**, **wb\_robot\_get\_battery\_sampling\_period**, **wb\_robot\_battery\_sensor\_get\_value** - *battery sensor function*
+#### `wb_robot_battery_sensor_enable`
+#### `wb_robot_battery_sensor_disable`
+#### `wb_robot_get_battery_sampling_period`
+#### `wb_robot_battery_sensor_get_value`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -352,7 +378,9 @@ double wb_robot_battery_sensor_get_value();
 int wb_robot_get_battery_sampling_period(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*battery sensor function*
 
 These functions allow you to measure the present energy level of the robot battery.
 First, it is necessary to enable battery sensor measurements by calling the `wb_robot_battery_sensor_enable` function.
@@ -366,9 +394,7 @@ The `wb_robot_get_battery_sampling_period` function returns the period given int
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_basic\_time\_step** - *returns the value of the basicTimeStep field of the WorldInfo node*
+#### `wb_robot_get_basic_time_step`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -378,15 +404,15 @@ The `wb_robot_get_battery_sampling_period` function returns the period given int
 double wb_robot_get_basic_time_step();
 ```
 
-**Description**
+##### Description
+
+*returns the value of the basicTimeStep field of the WorldInfo node*
 
 This function returns the value of the `basicTimeStep` field of the [WorldInfo](worldinfo.md) node.
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_mode** - *get operating mode, simulation versus real robot*
+#### `wb_robot_get_mode`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -397,7 +423,9 @@ int wb_robot_get_mode();
 void wb_robot_set_mode(int mode, void *arg);
 ```
 
-**Description**
+##### Description
+
+*get operating mode, simulation versus real robot*
 
 The `wb_robot_get_mode` function returns an integer value indicating the current operating mode for the controller.
 
@@ -419,9 +447,7 @@ The integers can be compared to the following enumeration items:
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_name** - *return the name defined in the robot node*
+#### `wb_robot_get_name`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -431,7 +457,9 @@ The integers can be compared to the following enumeration items:
 const char *wb_robot_get_name();
 ```
 
-**Description**
+##### Description
+
+*return the name defined in the robot node*
 
 This function returns the name as it is defined in the name field of the robot node (Robot, DifferentialWheels, Supervisor, etc.) in the current world file.
 The string returned should not be deallocated, as it was allocated by the "libController" shared library and will be deallocated when the controller terminates.
@@ -442,9 +470,7 @@ This sample world is located in the "projects/samples/demos/worlds" directory of
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_model** - *return the model defined in the robot node*
+#### `wb_robot_get_model`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -454,16 +480,17 @@ This sample world is located in the "projects/samples/demos/worlds" directory of
 const char *wb_robot_get_model();
 ```
 
-**Description**
+##### Description
+
+*return the model defined in the robot node*
 
 This function returns the model string as it is defined in the model field of the robot node (Robot, DifferentialWheels, Supervisor, etc.) in the current world file.
 The string returned should not be deallocated, as it was allocated by the "libController" shared library and will be deallocated when the controller terminates.
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_custom\_data**, **wb\_robot\_set\_custom\_data** - *return the custom data defined in the robot node*
+#### `wb_robot_get_custom_data`
+#### `wb_robot_set_custom_data`
 
  - *set the data defined in the robot node*
 
@@ -476,7 +503,9 @@ const char * wb_robot_get_custom_data();
 void wb_robot_set_custom_data(const char *data);
 ```
 
-**Description**
+##### Description
+
+*return the custom data defined in the robot node*
 
 The `wb_robot_get_custom_data` function returns the string contained in the `customData` field of the robot node.
 
@@ -484,9 +513,7 @@ The `wb_robot_set_custom_data` function set the string contained in the `customD
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_type** - *return the type of the robot node*
+#### `wb_robot_get_type`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -497,15 +524,15 @@ The `wb_robot_set_custom_data` function set the string contained in the `customD
 WbNodeType wb_robot_get_type();
 ```
 
-**Description**
+##### Description
+
+*return the type of the robot node*
 
 This function returns the type of the current mode (WB\_NODE\_ROBOT, WB\_NODE\_SUPERVISOR or WB\_NODE\_DIFFERENTIAL\_WHEELS).
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_project\_path** - *return the full path of the current project*
+#### `wb_robot_get_project_path`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -515,7 +542,9 @@ This function returns the type of the current mode (WB\_NODE\_ROBOT, WB\_NODE\_S
 const char *wb_robot_get_project_path();
 ```
 
-**Description**
+##### Description
+
+*return the full path of the current project*
 
 This function returns the full path of the current project, that is the directory which contains the worlds and controllers subdirectories (among others) of the current simulation world.
 It doesn't include the final directory separator char (slash or anti-slash).
@@ -524,9 +553,7 @@ It should not be deallocated.
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_world\_path** - *return the full path of the current opened world file*
+#### `wb_robot_get_world_path`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -536,7 +563,9 @@ It should not be deallocated.
 const char *wb_robot_get_world_path();
 ```
 
-**Description**
+##### Description
+
+*return the full path of the current opened world file*
 
 This function returns the full path of the current opened world.
 The returned pointer is a UTF-8 encoded char string which does include the final ".wbt".
@@ -544,9 +573,8 @@ It should not be deallocated.
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_controller\_name**, **wb\_robot\_get\_controller\_arguments** - *return the content of the Robot::controller and Robot::controllerArgs fields*
+#### `wb_robot_get_controller_name`
+#### `wb_robot_get_controller_arguments`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -557,15 +585,15 @@ const char *wb_robot_get_controller_name();
 const char *wb_robot_get_controller_arguments();
 ```
 
-**Description**
+##### Description
+
+*return the content of the `Robot::controller` and `Robot::controllerArgs` fields*
 
 These functions return the content of respectively the Robot::controller and the Robot::controllerArgs fields.
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_synchronization** - *return the value of the synchronization field of the Robot node*
+#### `wb_robot_get_synchronization`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -575,15 +603,15 @@ These functions return the content of respectively the Robot::controller and the
 bool wb_robot_get_synchronization();
 ```
 
-**Description**
+##### Description
+
+*return the value of the synchronization field of the Robot node*
 
 This function returns the boolean value corresponding to the synchronization field of the Robot node.
 
 ---
 
-**Name**
-
-**wb\_robot\_get\_time** - *return the current simulation time in seconds*
+#### `wb_robot_get_time`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -593,7 +621,9 @@ This function returns the boolean value corresponding to the synchronization fie
 double wb_robot_get_time();
 ```
 
-**Description**
+##### Description
+
+*return the current simulation time in seconds*
 
 This function returns the current simulation time in seconds.
 This correspond to the simulation time displayed in the speedometer located in the main toolbar.
@@ -601,9 +631,7 @@ It does not matter whether the controller is synchronized or not.
 
 ---
 
-**Name**
-
-**wb\_robot\_task\_new** - *start a new thread of execution*
+#### `wb_robot_task_new`
 
 ```c
 #include <webots/robot.h>
@@ -611,7 +639,9 @@ It does not matter whether the controller is synchronized or not.
 void wb_robot_task_new(void (*task, void *param);
 ```
 
-**Description**
+##### Description
+
+*start a new thread of execution*
 
 This function creates and starts a new thread of execution for the robot controller.
 The `task` function is immediately called using the `param` parameter.
@@ -619,15 +649,16 @@ It will end only when the `task` function returns.
 The Webots controller API is thread safe, however, some API functions use or return pointers to data structures which are not protected outside the function against asynchronous access from a different thread.
 Hence you should use mutexes (see below) to ensure that such data is not accessed by a different thread.
 
-**See also**
+##### See also
 
 [`wb_robot_mutex_new`](#wb_robot_mutex_new).
 
 ---
 
-**Name**
-
-**wb\_robot\_mutex\_new**, **wb\_robot\_mutex\_delete**, **wb\_robot\_mutex\_lock**, **wb\_robot\_mutex\_unlock** - *mutex functions*
+#### `wb_robot_mutex_new`
+#### `wb_robot_mutex_delete`
+#### `wb_robot_mutex_lock`
+#### `wb_robot_mutex_unlock`
 
 ```c
 #include <webots/robot.h>
@@ -638,7 +669,9 @@ void wb_robot_mutex_lock(WbMutexRef mutex);
 void wb_robot_mutex_unlock(WBMutexRef mutex);
 ```
 
-**Description**
+##### Description
+
+*mutex functions*
 
 The `wb_robot_mutex_new` function creates a new mutex and returns a reference to that mutex to be used with other mutex functions.
 A newly created mutex is always initially unlocked.
@@ -653,7 +686,7 @@ This function returns only after it has locked the specified `mutex`.
 
 The `wb_robot_mutex_unlock` function unlocks the specified `mutex`, allowing other threads to lock it.
 
-**See also**
+##### See also
 
 [`wb_robot_task_new`](#wb_robot_task_new).
 
@@ -661,9 +694,10 @@ Users unfamiliar with the mutex concept may wish to consult a reference on multi
 
 ---
 
-**Name**
-
-**wb\_robot\_wwi\_receive**, **wb\_robot\_wwi\_receive\_text**, **wb\_robot\_wwi\_send**, **wb\_robot\_wwi\_send\_text** - *communication with a HTML robot window*
+#### `wb_robot_wwi_receive`
+#### `wb_robot_wwi_receive_text`
+#### `wb_robot_wwi_send`
+#### `wb_robot_wwi_send_text`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -676,7 +710,9 @@ void wb_robot_wwi_send(const char *data, int size);
 void wb_robot_wwi_send_text(const char *text);
 ```
 
-**Description**
+##### Description
+
+*communication with a HTML robot window*
 
 These functions allow the robot controller to communicate with a HTML robot window.
 Such a window is embedded as a dockable sub-window in the Webots user interface.
@@ -692,9 +728,7 @@ The message is received using the `webots.window("<robot window name>").receive`
 
 ---
 
-**Name**
-
-**wb\_robot\_window\_custom\_function** - *communication with the native C/C++ robot window [deprecated]*
+#### `wb_robot_window_custom_function`
 
 [C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
@@ -704,7 +738,9 @@ The message is received using the `webots.window("<robot window name>").receive`
 void *wb_robot_window_custom_function(void *arg);
 ```
 
-**Description**
+##### Description
+
+*communication with the native C/C++ robot window [deprecated]*
 
 The `wb_robot_window_custom_function` function allows a robot controller to communicate with the native C/C++ robot window plugin.
 Native robot windows are deprecated and instead it is recommended to use the HTML robot windows and their API functions: [`wb_robot_wwi_receive_text`](#wb_robot_wwi_receive_text) and [`wb_robot_wwi_send_text`](#wb_robot_wwi_send_text).

--- a/reference/robot.md
+++ b/reference/robot.md
@@ -116,7 +116,7 @@ Asynchronous controllers may also be recommended for networked simulations invol
 
 **wb\_robot\_step**, **wb\_robot\_init**, **wb\_robot\_cleanup** - *controller step, initialization and cleanup functions*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -295,7 +295,7 @@ Instead, C and Matlab users should use [`wb_robot_get_device`](#wb_robot_get_dev
 
 **wb\_robot\_get\_device\_by\_index** - *get the devices by introspection*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -341,7 +341,7 @@ for(i=0; i<n_devices; i++) {
 
 **wb\_robot\_battery\_sensor\_enable**, **wb\_robot\_battery\_sensor\_disable**, **wb\_robot\_get\_battery\_sampling\_period**, **wb\_robot\_battery\_sensor\_get\_value** - *battery sensor function*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -370,7 +370,7 @@ The `wb_robot_get_battery_sampling_period` function returns the period given int
 
 **wb\_robot\_get\_basic\_time\_step** - *returns the value of the basicTimeStep field of the WorldInfo node*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -388,7 +388,7 @@ This function returns the value of the `basicTimeStep` field of the [WorldInfo](
 
 **wb\_robot\_get\_mode** - *get operating mode, simulation versus real robot*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -423,7 +423,7 @@ The integers can be compared to the following enumeration items:
 
 **wb\_robot\_get\_name** - *return the name defined in the robot node*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -446,7 +446,7 @@ This sample world is located in the "projects/samples/demos/worlds" directory of
 
 **wb\_robot\_get\_model** - *return the model defined in the robot node*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -467,7 +467,7 @@ The string returned should not be deallocated, as it was allocated by the "libCo
 
  - *set the data defined in the robot node*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -488,7 +488,7 @@ The `wb_robot_set_custom_data` function set the string contained in the `customD
 
 **wb\_robot\_get\_type** - *return the type of the robot node*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/nodes.h>
@@ -507,7 +507,7 @@ This function returns the type of the current mode (WB\_NODE\_ROBOT, WB\_NODE\_S
 
 **wb\_robot\_get\_project\_path** - *return the full path of the current project*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -528,7 +528,7 @@ It should not be deallocated.
 
 **wb\_robot\_get\_world\_path** - *return the full path of the current opened world file*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -548,7 +548,7 @@ It should not be deallocated.
 
 **wb\_robot\_get\_controller\_name**, **wb\_robot\_get\_controller\_arguments** - *return the content of the Robot::controller and Robot::controllerArgs fields*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -567,7 +567,7 @@ These functions return the content of respectively the Robot::controller and the
 
 **wb\_robot\_get\_synchronization** - *return the value of the synchronization field of the Robot node*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -585,7 +585,7 @@ This function returns the boolean value corresponding to the synchronization fie
 
 **wb\_robot\_get\_time** - *return the current simulation time in seconds*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -665,7 +665,7 @@ Users unfamiliar with the mutex concept may wish to consult a reference on multi
 
 **wb\_robot\_wwi\_receive**, **wb\_robot\_wwi\_receive\_text**, **wb\_robot\_wwi\_send**, **wb\_robot\_wwi\_send\_text** - *communication with a HTML robot window*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/utils/default_robot_window.h>
@@ -696,7 +696,7 @@ The message is received using the `webots.window("<robot window name>").receive`
 
 **wb\_robot\_window\_custom\_function** - *communication with the native C/C++ robot window [deprecated]*
 
-{[C++](cpp-api.md#cpp_robot)}, {[Java](java-api.md#java_robot)}, {[Python](python-api.md#python_robot)}, {[Matlab](matlab-api.md#matlab_robot)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot_window.h>

--- a/reference/robot.md
+++ b/reference/robot.md
@@ -236,7 +236,7 @@ If the specified device is not found, the function returns 0.
 > **Note**: This function is not available in the C++, Java and Python APIs.
 Instead, C++, Java and Python users should use device specific typed methods (see below).
 
-##### See also
+##### See Also
 
 [`wb_robot_step`](#wb_robot_step).
 
@@ -310,7 +310,7 @@ If the specified device is not found, the function returns `NULL` in C++, `null`
 > **Note**: These functions are not available in the C and MATLAB APIs.
 Instead, C and Matlab users should use [`wb_robot_get_device`](#wb_robot_get_device) function.
 
-##### See also
+##### See Also
 
 [`wb_robot_get_device`](#wb_robot_get_device), [`wb_robot_step`](#wb_robot_step).
 
@@ -649,7 +649,7 @@ It will end only when the `task` function returns.
 The Webots controller API is thread safe, however, some API functions use or return pointers to data structures which are not protected outside the function against asynchronous access from a different thread.
 Hence you should use mutexes (see below) to ensure that such data is not accessed by a different thread.
 
-##### See also
+##### See Also
 
 [`wb_robot_mutex_new`](#wb_robot_mutex_new).
 
@@ -686,7 +686,7 @@ This function returns only after it has locked the specified `mutex`.
 
 The `wb_robot_mutex_unlock` function unlocks the specified `mutex`, allowing other threads to lock it.
 
-##### See also
+##### See Also
 
 [`wb_robot_task_new`](#wb_robot_task_new).
 

--- a/reference/speaker.md
+++ b/reference/speaker.md
@@ -14,9 +14,7 @@ It can be used to play sounds and perform text-to-speech from the controller API
 
 ### Speaker Functions
 
-**Name**
-
-**wb\_speaker\_play\_sound** - *plays a sound*
+#### `wb_speaker_play_sound`
 
 [C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [Matlab](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
 
@@ -26,7 +24,9 @@ It can be used to play sounds and perform text-to-speech from the controller API
 void wb_speaker_play_sound(WbDeviceTag left, WbDeviceTag right, const char *sound, double volume, double pitch, double balance, bool loop);
 ```
 
-**Description**
+##### Description
+
+*plays a sound*
 
 This function allows the user to play a sound file.
 Currently only wave files are supported.
@@ -54,9 +54,7 @@ If not found there and if the robot is a PROTO, it will be searched relatively t
 
 ---
 
-**Name**
-
-**wb\_speaker\_stop** - *stops the speaker*
+#### `wb_speaker_stop`
 
 [C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [Matlab](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
 
@@ -66,7 +64,9 @@ If not found there and if the robot is a PROTO, it will be searched relatively t
 void wb_speaker_stop(WbDeviceTag tag, const char *sound);
 ```
 
-**Description**
+##### Description
+
+*stops the speaker*
 
 This function stops a specific sound.
 The `sound` argument is the path to an audio file currently playing in the speaker.
@@ -76,9 +76,11 @@ It is possible to stop all the sounds currently playing in a speaker by setting 
 
 ---
 
-**Name**
-
-**wb\_speaker\_set\_engine**, **wb\_speaker\_set\_language**, **wb\_speaker\_get\_engine**, **wb\_speaker\_get\_language**, **wb\_speaker\_speak** - *perform text-to-speech*
+#### `wb_speaker_set_engine`
+#### `wb_speaker_set_language`
+#### `wb_speaker_get_engine`
+#### `wb_speaker_get_language`
+#### `wb_speaker_speak`
 
 [C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [Matlab](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
 
@@ -92,7 +94,9 @@ const char *wb_speaker_get_language(WbDeviceTag tag);
 void wb_speaker_speak(WbDeviceTag tag, const char *text, double volume);
 ```
 
-**Description**
+##### Description
+
+*perform text-to-speech*
 
 The `wb_speaker_set_engine` function allows the user to set the text-to-speech engine that is going to be used by a speaker.
 The `engine` parameter should be one of the following values:

--- a/reference/speaker.md
+++ b/reference/speaker.md
@@ -18,7 +18,7 @@ It can be used to play sounds and perform text-to-speech from the controller API
 
 **wb\_speaker\_play\_sound** - *plays a sound*
 
-{[C++](cpp-api.md#cpp_speaker)}, {[Java](java-api.md#java_speaker)}, {[Python](python-api.md#python_speaker)}, {[Matlab](matlab-api.md#matlab_speaker)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [Matlab](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
 
 ```c
 #include <webots/speaker.h>
@@ -58,7 +58,7 @@ If not found there and if the robot is a PROTO, it will be searched relatively t
 
 **wb\_speaker\_stop** - *stops the speaker*
 
-{[C++](cpp-api.md#cpp_speaker)}, {[Java](java-api.md#java_speaker)}, {[Python](python-api.md#python_speaker)}, {[Matlab](matlab-api.md#matlab_speaker)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [Matlab](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
 
 ```c
 #include <webots/speaker.h>
@@ -80,7 +80,7 @@ It is possible to stop all the sounds currently playing in a speaker by setting 
 
 **wb\_speaker\_set\_engine**, **wb\_speaker\_set\_language**, **wb\_speaker\_get\_engine**, **wb\_speaker\_get\_language**, **wb\_speaker\_speak** - *perform text-to-speech*
 
-{[C++](cpp-api.md#cpp_speaker)}, {[Java](java-api.md#java_speaker)}, {[Python](python-api.md#python_speaker)}, {[Matlab](matlab-api.md#matlab_speaker)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [Matlab](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
 
 ```c
 #include <webots/speaker.h>

--- a/reference/supervisor.md
+++ b/reference/supervisor.md
@@ -513,7 +513,7 @@ For example the vector `[1 0 1]` represents the magenta color.
 
 ---
 
-##### `wb_supervisor_simulation_quit`
+#### `wb_supervisor_simulation_quit`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -610,8 +610,8 @@ You may wish to save some data in a file from your supervisor program in order t
 
 ---
 
-##### `wb_supervisor_simulation_get_mode`
-##### `wb_supervisor_simulation_set_mode`
+#### `wb_supervisor_simulation_get_mode`
+#### `wb_supervisor_simulation_set_mode`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 

--- a/reference/supervisor.md
+++ b/reference/supervisor.md
@@ -33,7 +33,7 @@ As for a regular [Robot](robot.md) controller, the `wb_robot_init`, `wb_robot_st
 **wb\_supervisor\_export\_image** - *save the current 3D image of the simulator into a JPEG file, suitable for
     building a webcam system*
 
-{[C++](cpp-api.md#cpp_supervisor)}, {[Java](java-api.md#java_supervisor)}, {[Python](python-api.md#python_supervisor)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -61,7 +61,7 @@ In this example, the [Supervisor](#supervisor) controller takes a snapshot image
 
 **wb\_supervisor\_node\_get\_from\_def**, **wb\_supervisor\_node\_get\_def**, **wb\_supervisor\_node\_get\_from\_id**, **wb\_supervisor\_node\_get\_id**, **wb\_supervisor\_node\_get\_parent\_node**, **wb\_supervisor\_node\_get\_root**, **wb\_supervisor\_node\_get\_self**, **wb\_supervisor\_node\_get\_selected** - *get a handle to a node in the world*
 
-{[C++](cpp-api.md#cpp_supervisor)}, {[Java](java-api.md#java_supervisor)}, {[Python](python-api.md#python_supervisor)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -120,7 +120,7 @@ If no node is currently selected, the function returns NULL.
 
 **wb\_supervisor\_node\_get\_type**, **wb\_supervisor\_node\_get\_type\_name**, **wb\_supervisor\_node\_get\_base\_type\_name** - *get information on a specified node*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -154,7 +154,7 @@ These integers can be directly compared with the output of the `Node::getType` f
 
 **wb\_supervisor\_node\_remove** - *Remove a specified node*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -172,7 +172,7 @@ The `wb_supervisor_node_remove` function removes the node specified as an argume
 
 **wb\_supervisor\_node\_get\_field** - *get a field reference from a node*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -196,7 +196,7 @@ Otherwise, it returns a handler to a field.
 
 **wb\_supervisor\_node\_get\_position**, **wb\_supervisor\_node\_get\_orientation** - *get the global (world) position/orientation of a node*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -246,7 +246,7 @@ The "WEBOTS\_HOME/projects/robots/ipr/worlds/ipr\_cube.wbt" project shows how to
 
 **wb\_supervisor\_node\_get\_center\_of\_mass** - *get the global position of a solid's center of mass*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -271,7 +271,7 @@ The "WEBOTS\_HOME/projects/samples/.wbt" project shows how to use this function.
 
 **wb\_supervisor\_node\_get\_contact\_point** - *get the contact point with given index in the contact point list of the given solid.*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -298,7 +298,7 @@ The "WEBOTS\_HOME/projects/samples/howto/worlds/cylinder\_stack.wbt" project sho
 
 **wb\_supervisor\_node\_get\_number\_of\_contact\_points** - *get the number of contact points of the given solid*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -319,7 +319,7 @@ The "WEBOTS\_HOME/projects/samples/howto/worlds/cylinder\_stack.wbt" project sho
 
 **wb\_supervisor\_node\_get\_static\_balance** - *return the boolean value of the static balance test based on the support polygon of a solid*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -341,7 +341,7 @@ The test consists in checking whether the projection of the center of mass onto 
 
 **wb\_supervisor\_node\_get\_velocity**, **wb\_supervisor\_node\_set\_velocity** - *get/set the angular and linear velocities of a Solid node.*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -370,7 +370,7 @@ The last three are respectively the angular velocities around the x, y and z axe
 
 **wb\_supervisor\_node\_reset\_physics** - *stops the inertia of the given solid*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -392,7 +392,7 @@ To stop the inertia of all available solids please refer to [this section](#wb_s
 
 **wb\_supervisor\_node\_restart\_controller** - *restarts the controller of the given robot*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -412,7 +412,7 @@ Note that if a robot window is specified for the [Robot](robot.md) node, the rob
 
 **wb\_supervisor\_node\_set\_visibility** - *set the visibility of a node*
 
-{[C++](cpp-api.md#cpp_node)}, {[Java](java-api.md#java_node)}, {[Python](python-api.md#python_node)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -437,7 +437,7 @@ It is relevant to show a node only if it was previously hidden using this functi
 
 **wb\_supervisor\_set\_label** - *overlay a text label on the 3D scene*
 
-{[C++](cpp-api.md#cpp_supervisor)}, {[Java](java-api.md#java_supervisor)}, {[Python](python-api.md#python_supervisor)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -507,7 +507,7 @@ For example the vector `[1 0 1]` represents the magenta color.
 
 **wb\_supervisor\_simulation\_quit** - *terminate the simulator and controller processes*
 
-{[C++](cpp-api.md#cpp_supervisor)}, {[Java](java-api.md#java_supervisor)}, {[Python](python-api.md#python_supervisor)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -584,7 +584,7 @@ int main(int argc, char *argv[]) {
 
 **wb\_supervisor\_simulation\_revert** - *reload the current world*
 
-{[C++](cpp-api.md#cpp_supervisor)}, {[Java](java-api.md#java_supervisor)}, {[Python](python-api.md#python_supervisor)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -604,7 +604,7 @@ You may wish to save some data in a file from your supervisor program in order t
 
 **wb\_supervisor\_simulation\_get\_mode**, **wb\_supervisor\_simulation\_set\_mode** - *get and set the simulation mode*
 
-{[C++](cpp-api.md#cpp_supervisor)}, {[Java](java-api.md#java_supervisor)}, {[Python](python-api.md#python_supervisor)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -643,7 +643,7 @@ The current simulation mode can also be modified by the Webots user, when he's c
 
 **wb\_supervisor\_load\_world**, **wb\_supervisor\_save\_world** - *Load or save the current world.*
 
-{[C++](cpp-api.md#cpp_supervisor)}, {[Java](java-api.md#java_supervisor)}, {[Python](python-api.md#python_supervisor)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -675,7 +675,7 @@ In this case, a simple save operation is performed.
 
 **wb\_supervisor\_simulation\_reset\_physics** - *stop the inertia of all solids in the world and reset the random number generator*
 
-{[C++](cpp-api.md#cpp_supervisor)}, {[Java](java-api.md#java_supervisor)}, {[Python](python-api.md#python_supervisor)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -697,7 +697,7 @@ To stop the inertia of a single [Solid](solid.md) node please refer to [this sec
 
 **wb\_supervisor\_movie\_start\_recording**, **wb\_supervisor\_movie\_stop\_recording**, **wb\_supervisor\_movie\_is\_ready**, **wb\_supervisor\_movie\_failed** - *export the current simulation into a movie file*
 
-{[C++](cpp-api.md#cpp_supervisor)}, {[Java](java-api.md#java_supervisor)}, {[Python](python-api.md#python_supervisor)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -739,7 +739,7 @@ After starting a new recording process the returned value is reset to `FALSE`.
 
 **wb\_supervisor\_animation\_start\_recording**, **wb\_supervisor\_animation\_stop\_recording** - *export the current simulation into an animation file*
 
-{[C++](cpp-api.md#cpp_supervisor)}, {[Java](java-api.md#java_supervisor)}, {[Python](python-api.md#python_supervisor)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -766,7 +766,7 @@ Both `wb_supervisor_animation_start_recording` and `wb_supervisor_animation_stop
 
 **wb\_supervisor\_field\_get\_type**, **wb\_supervisor\_field\_get\_type\_name**, **wb\_supervisor\_field\_get\_count** - *get a handler and more information on a field in a node*
 
-{[C++](cpp-api.md#cpp_field)}, {[Java](java-api.md#java_field)}, {[Python](python-api.md#python_field)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -799,7 +799,7 @@ These integers can be directly compared with the output of the `Field::getType` 
 
 **wb\_supervisor\_field\_get\_sf\_bool**, **wb\_supervisor\_field\_get\_sf\_int32**, **wb\_supervisor\_field\_get\_sf\_float**, **wb\_supervisor\_field\_get\_sf\_vec2f**, **wb\_supervisor\_field\_get\_sf\_vec3f**, **wb\_supervisor\_field\_get\_sf\_rotation**, **wb\_supervisor\_field\_get\_sf\_color**, **wb\_supervisor\_field\_get\_sf\_string**, **wb\_supervisor\_field\_get\_sf\_node**, **wb\_supervisor\_field\_get\_mf\_bool**, **wb\_supervisor\_field\_get\_mf\_int32**, **wb\_supervisor\_field\_get\_mf\_float**, **wb\_supervisor\_field\_get\_mf\_vec2f**, **wb\_supervisor\_field\_get\_mf\_vec3f**, **wb\_supervisor\_field\_get\_mf\_rotation**, **wb\_supervisor\_field\_get\_mf\_color**, **wb\_supervisor\_field\_get\_mf\_string**, **wb\_supervisor\_field\_get\_mf\_node** - *get the value of a field*
 
-{[C++](cpp-api.md#cpp_field)}, {[Java](java-api.md#java_field)}, {[Python](python-api.md#python_field)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -843,7 +843,7 @@ The type of the field has to match the name of the function used and the index s
 
 **wb\_supervisor\_field\_set\_sf\_bool**, **wb\_supervisor\_field\_set\_sf\_int32**, **wb\_supervisor\_field\_set\_sf\_float**, **wb\_supervisor\_field\_set\_sf\_vec2f**, **wb\_supervisor\_field\_set\_sf\_vec3f**, **wb\_supervisor\_field\_set\_sf\_rotation**, **wb\_supervisor\_field\_set\_sf\_color**, **wb\_supervisor\_field\_set\_sf\_string**, **wb\_supervisor\_field\_set\_mf\_bool**, **wb\_supervisor\_field\_set\_mf\_int32**, **wb\_supervisor\_field\_set\_mf\_float**, **wb\_supervisor\_field\_set\_mf\_vec2f**, **wb\_supervisor\_field\_set\_mf\_vec3f**, **wb\_supervisor\_field\_set\_mf\_rotation**, **wb\_supervisor\_field\_set\_mf\_color**, **wb\_supervisor\_field\_set\_mf\_string** - *set the value of a field*
 
-{[C++](cpp-api.md#cpp_field)}, {[Java](java-api.md#java_field)}, {[Python](python-api.md#python_field)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -898,7 +898,7 @@ The "soccer.wbt" world, located in the "projects/samples/demos/worlds" directory
 
 **wb\_supervisor\_field\_insert\_mf\_bool**, **wb\_supervisor\_field\_insert\_mf\_int32**, **wb\_supervisor\_field\_insert\_mf\_float**, **wb\_supervisor\_field\_insert\_mf\_vec2f**, **wb\_supervisor\_field\_insert\_mf\_vec3f**, **wb\_supervisor\_field\_insert\_mf\_rotation**, **wb\_supervisor\_field\_insert\_mf\_color**, **wb\_supervisor\_field\_insert\_mf\_string**, **wb\_supervisor\_field\_remove\_mf** - *insert or remove a value in a field*
 
-{[C++](cpp-api.md#cpp_field)}, {[Java](java-api.md#java_field)}, {[Python](python-api.md#python_field)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -938,7 +938,7 @@ The `wb_supervisor_field_remove_mf` function removes an item from a specified mu
 
 **wb\_supervisor\_field\_import\_mf\_node**, **wb\_supervisor\_field\_import\_mf\_node\_from\_string** - *import a node into an MF\_NODE field (typically a "children" field)*
 
-{[C++](cpp-api.md#cpp_field)}, {[Java](java-api.md#java_field)}, {[Python](python-api.md#python_field)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -1001,7 +1001,7 @@ For example, a device imported into a Robot node doesn't reset the Robot, so the
 
 **wb\_supervisor\_virtual\_reality\_headset\_is\_used**, **wb\_supervisor\_virtual\_reality\_headset\_get\_position**, **wb\_supervisor\_virtual\_reality\_headset\_get\_orientation** - *check if a virtual reality headset is used and get its position and orientation*
 
-{[C++](cpp-api.md#cpp_supervisor)}, {[Java](java-api.md#java_supervisor)}, {[Python](python-api.md#python_supervisor)}, {[Matlab](matlab-api.md#matlab_supervisor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>

--- a/reference/supervisor.md
+++ b/reference/supervisor.md
@@ -28,10 +28,7 @@ For functions returning a string, an empty string is returned instead of a NULL 
 
 As for a regular [Robot](robot.md) controller, the `wb_robot_init`, `wb_robot_step`, etc. functions must be used in a [Supervisor](#supervisor) controller.
 
-**Name**
-
-**wb\_supervisor\_export\_image** - *save the current 3D image of the simulator into a JPEG file, suitable for
-    building a webcam system*
+#### `wb_supervisor_export_image`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -41,7 +38,9 @@ As for a regular [Robot](robot.md) controller, the `wb_robot_init`, `wb_robot_st
 void wb_supervisor_export_image(const char *filename, int quality);
 ```
 
-**Description**
+##### Description
+
+*save the current 3D image of the simulator into a JPEG file, suitable for building a webcam system*
 
 The `wb_supervisor_export_image` function saves the current image of Webots main window into a JPEG file as specified by the `filename` parameter.
 If the target file exists, it will be silently overwritten.
@@ -50,16 +49,21 @@ The `filename` parameter should specify a valid (absolute or relative) file name
 In fact, a temporary file is first saved, and then renamed to the requested `filename`.
 This avoids having a temporary unfinished (and hence corrupted) file for webcam applications.
 
-**Example**
+##### Example
 
 The "projects/samples/howto/worlds/supervisor.wbt" world provides an example on how to use the `wb_supervisor_export_image` function.
 In this example, the [Supervisor](#supervisor) controller takes a snapshot image each time a goal is scored.
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_get\_from\_def**, **wb\_supervisor\_node\_get\_def**, **wb\_supervisor\_node\_get\_from\_id**, **wb\_supervisor\_node\_get\_id**, **wb\_supervisor\_node\_get\_parent\_node**, **wb\_supervisor\_node\_get\_root**, **wb\_supervisor\_node\_get\_self**, **wb\_supervisor\_node\_get\_selected** - *get a handle to a node in the world*
+#### `wb_supervisor_node_get_from_def`
+#### `wb_supervisor_node_get_def`
+#### `wb_supervisor_node_get_from_id`
+#### `wb_supervisor_node_get_id`
+#### `wb_supervisor_node_get_parent_node`
+#### `wb_supervisor_node_get_root`
+#### `wb_supervisor_node_get_self`
+#### `wb_supervisor_node_get_selected`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -76,7 +80,9 @@ WbNodeRef wb_supervisor_node_get_self();
 WbNodeRef wb_supervisor_node_get_selected();
 ```
 
-**Description**
+##### Description
+
+*get a handle to a node in the world*
 
 The `wb_supervisor_node_get_from_def` function returns a handle to a node in the world from its DEF name.
 The return value can be used for subsequent calls to functions which require a `WbNodeRef` parameter.
@@ -116,9 +122,9 @@ If no node is currently selected, the function returns NULL.
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_get\_type**, **wb\_supervisor\_node\_get\_type\_name**, **wb\_supervisor\_node\_get\_base\_type\_name** - *get information on a specified node*
+#### `wb_supervisor_node_get_type`
+#### `wb_supervisor_node_get_type_name`
+#### `wb_supervisor_node_get_base_type_name`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -130,7 +136,9 @@ const char *wb_supervisor_node_get_type_name(WbNodeRef node);
 const char *wb_supervisor_node_get_base_type_name(WbNodeRef node);
 ```
 
-**Description**
+##### Description
+
+*get information on a specified node*
 
 The `wb_supervisor_node_get_type` function returns a symbolic value corresponding the type of the node specified as an argument.
 If the argument is NULL, it returns WB\_NODE\_NO\_NODE.
@@ -150,9 +158,7 @@ These integers can be directly compared with the output of the `Node::getType` f
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_remove** - *Remove a specified node*
+#### `wb_supervisor_node_remove`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -162,15 +168,15 @@ These integers can be directly compared with the output of the `Node::getType` f
 void wb_supervisor_node_remove(WbNodeRef node);
 ```
 
-**Description**
+##### Description
+
+*Remove a specified node*
 
 The `wb_supervisor_node_remove` function removes the node specified as an argument from the Webots scene tree.
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_get\_field** - *get a field reference from a node*
+#### `wb_supervisor_node_get_field`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -180,7 +186,9 @@ The `wb_supervisor_node_remove` function removes the node specified as an argume
 WbFieldRef wb_supervisor_node_get_field(WbNodeRef node, const char *field_name);
 ```
 
-**Description**
+##### Description
+
+*get a field reference from a node*
 
 The `wb_supervisor_node_get_field` function retrieves a handler to a node field.
 The field is specified by its name in `field_name` and the `node` it belongs to.
@@ -192,9 +200,8 @@ Otherwise, it returns a handler to a field.
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_get\_position**, **wb\_supervisor\_node\_get\_orientation** - *get the global (world) position/orientation of a node*
+#### `wb_supervisor_node_get_position`
+#### `wb_supervisor_node_get_orientation`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -205,7 +212,9 @@ const double *wb_supervisor_node_get_position(WbNodeRef node);
 const double *wb_supervisor_node_get_orientation(WbNodeRef node);
 ```
 
-**Description**
+##### Description
+
+*get the global (world) position/orientation of a node*
 
 The `wb_supervisor_node_get_position` function returns the position of a node expressed in the global (world) coordinate system.
 The `node` argument must be a [Transform](transform.md) node (or a derived node), otherwise the function will print a warning message and return 3 `NaN` (Not a Number) values.
@@ -242,9 +251,7 @@ The "WEBOTS\_HOME/projects/robots/ipr/worlds/ipr\_cube.wbt" project shows how to
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_get\_center\_of\_mass** - *get the global position of a solid's center of mass*
+#### `wb_supervisor_node_get_center_of_mass`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -254,7 +261,9 @@ The "WEBOTS\_HOME/projects/robots/ipr/worlds/ipr\_cube.wbt" project shows how to
 const double *wb_supervisor_node_get_center_of_mass(WbNodeRef node);
 ```
 
-**Description**
+##### Description
+
+*get the global position of a solid's center of mass*
 
 The `wb_supervisor_node_get_center_of_mass` function returns the position of the center of mass of a Solid node expressed in the global (world) coordinate system.
 The `node` argument must be a [Solid](solid.md) node (or a derived node), otherwise the function will print a warning message and return 3 `NaN` (Not a Number) values.
@@ -267,9 +276,7 @@ The "WEBOTS\_HOME/projects/samples/.wbt" project shows how to use this function.
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_get\_contact\_point** - *get the contact point with given index in the contact point list of the given solid.*
+#### `wb_supervisor_node_get_contact_point`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -279,7 +286,9 @@ The "WEBOTS\_HOME/projects/samples/.wbt" project shows how to use this function.
 const double *wb_supervisor_node_get_contact_point(WbNodeRef node, int index);
 ```
 
-**Description**
+##### Description
+
+*get the contact point with given index in the contact point list of the given solid.*
 
 The `wb_supervisor_node_get_contact_point` function returns the contact point with given index in the contact point list of the given `Solid`.
 The `wb_supervisor_node_get_number_of_contact_points` function allows you to retrieve the length of this list.
@@ -294,9 +303,7 @@ The "WEBOTS\_HOME/projects/samples/howto/worlds/cylinder\_stack.wbt" project sho
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_get\_number\_of\_contact\_points** - *get the number of contact points of the given solid*
+#### `wb_supervisor_node_get_number_of_contact_points`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -306,7 +313,9 @@ The "WEBOTS\_HOME/projects/samples/howto/worlds/cylinder\_stack.wbt" project sho
 int wb_supervisor_node_get_number_of_contact_points(WbNodeRef node);
 ```
 
-**Description**
+##### Description
+
+*get the number of contact points of the given solid*
 
 The `wb_supervisor_node_get_number_of_contact_points` function returns the number of contact points of the given `Solid`.
 The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent, otherwise the function will print a warning message and return `-1`.
@@ -315,9 +324,7 @@ The "WEBOTS\_HOME/projects/samples/howto/worlds/cylinder\_stack.wbt" project sho
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_get\_static\_balance** - *return the boolean value of the static balance test based on the support polygon of a solid*
+#### `wb_supervisor_node_get_static_balance`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -327,7 +334,9 @@ The "WEBOTS\_HOME/projects/samples/howto/worlds/cylinder\_stack.wbt" project sho
 bool wb_supervisor_node_get_static_balance(WbNodeRef node);
 ```
 
-**Description**
+##### Description
+
+*return the boolean value of the static balance test based on the support polygon of a solid*
 
 The `wb_supervisor_node_get_static_balance` function returns the boolean value of the static balance test based on the support polygon of a solid.
 The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent.
@@ -337,9 +346,8 @@ The test consists in checking whether the projection of the center of mass onto 
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_get\_velocity**, **wb\_supervisor\_node\_set\_velocity** - *get/set the angular and linear velocities of a Solid node.*
+#### `wb_supervisor_node_get_velocity`
+#### `wb_supervisor_node_set_velocity`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -350,7 +358,9 @@ const double *wb_supervisor_node_get_velocity(WbNodeRef node);
 void wb_supervisor_node_set_velocity(WbNodeRef node, const double velocity[6]);
 ```
 
-**Description**
+##### Description
+
+*get/set the angular and linear velocities of a Solid node.*
 
 The `wb_supervisor_node_get_velocity` function returns the velocity (both linear and angular) of a node.
 The `node` argument must be a [Solid](solid.md) node (or a derived node), otherwise the function will print a warning message and return 6 `NaN` (Not a Number) values.
@@ -366,9 +376,7 @@ The last three are respectively the angular velocities around the x, y and z axe
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_reset\_physics** - *stops the inertia of the given solid*
+#### `wb_supervisor_node_reset_physics`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -378,7 +386,9 @@ The last three are respectively the angular velocities around the x, y and z axe
 void wb_supervisor_node_reset_physics(WbNodeRef node);
 ```
 
-**Description**
+##### Description
+
+*stops the inertia of the given solid*
 
 The `wb_supervisor_node_reset_physics` function stops the inertia of the given solid.
 If the specified node is physics-enables, i.e. it contains a [Physics](physics.md) node, then the linear and angular velocities of the corresonding body are reset to 0, hence the inertia is also zeroed.
@@ -388,9 +398,7 @@ To stop the inertia of all available solids please refer to [this section](#wb_s
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_restart\_controller** - *restarts the controller of the given robot*
+#### `wb_supervisor_node_restart_controller`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -400,7 +408,9 @@ To stop the inertia of all available solids please refer to [this section](#wb_s
 void wb_supervisor_node_restart_controller(WbNodeRef node);
 ```
 
-**Description**
+##### Description
+
+*restarts the controller of the given robot*
 
 The `wb_supervisor_node_restart_controller` function restarts the controller of the Robot passed to it.
 If a node other than a [Robot](robot.md) is passed to this function, no change is effected, and a warning message is printed to the console.
@@ -408,9 +418,7 @@ Note that if a robot window is specified for the [Robot](robot.md) node, the rob
 
 ---
 
-**Name**
-
-**wb\_supervisor\_node\_set\_visibility** - *set the visibility of a node*
+#### `wb_supervisor_node_set_visibility`
 
 [C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -420,7 +428,9 @@ Note that if a robot window is specified for the [Robot](robot.md) node, the rob
 void wb_supervisor_node_set_visibility(WbNodeRef node, WbNodeRef from, bool visible);
 ```
 
-**Description**
+##### Description
+
+*set the visibility of a node*
 
 The `wb_supervisor_node_set_visibility` function sets the visibility of a node from the specified [Camera](camera.md), [Lidar](lidar.md), [RangeFinder](rangefinder.md) or [Viewpoint](viewpoint.md) node.
 In particular it defines if the node is visible in the image recorded by the `from` device.
@@ -433,9 +443,7 @@ It is relevant to show a node only if it was previously hidden using this functi
 
 ---
 
-**Name**
-
-**wb\_supervisor\_set\_label** - *overlay a text label on the 3D scene*
+#### `wb_supervisor_set_label`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -445,7 +453,9 @@ It is relevant to show a node only if it was previously hidden using this functi
 void wb_supervisor_set_label(int id, const char *text, double x, double y, double size, int color, double transparency, const char *font);
 ```
 
-**Description**
+##### Description
+
+*overlay a text label on the 3D scene*
 
 The `wb_supervisor_set_label` function displays a text label overlaying the 3D scene in Webots' main window.
 The `id` parameter is an identifier for the label; you can choose any value in the range 0 to 65534.
@@ -477,7 +487,7 @@ Finally, the `font` parameter defines the font used to draw the text, the follow
 -  Trebuchet MS
 -  Verdana
 
-**Examples**
+##### Examples
 
 ```c
 wb_supervisor_set_label(0,"hello world",0,0,0.1,0xff0000,0,"Arial");
@@ -503,9 +513,7 @@ For example the vector `[1 0 1]` represents the magenta color.
 
 ---
 
-**Name**
-
-**wb\_supervisor\_simulation\_quit** - *terminate the simulator and controller processes*
+##### `wb_supervisor_simulation_quit`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -515,7 +523,9 @@ For example the vector `[1 0 1]` represents the magenta color.
 void wb_supervisor_simulation_quit(int status);
 ```
 
-**Description**
+##### Description
+
+*terminate the simulator and controller processes*
 
 The `wb_supervisor_simulator_quit` function quits Webots, as if one was using the menu `File / Quit Webots`.
 This function makes it easier to invoke a Webots simulation from a script because it allows to terminate the simulation automatically, without human intervention.
@@ -580,9 +590,7 @@ int main(int argc, char *argv[]) {
 
 ---
 
-**Name**
-
-**wb\_supervisor\_simulation\_revert** - *reload the current world*
+#### `wb_supervisor_simulation_revert`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -592,7 +600,9 @@ int main(int argc, char *argv[]) {
 void wb_supervisor_simulation_revert();
 ```
 
-**Description**
+##### Description
+
+*reload the current world*
 
 The `wb_supervisor_simulator_revert` function sends a request to the simulator process, asking it to reload the current world immediately.
 As a result of reloading the current world, the supervisor process and all the robot processes are terminated and restarted.
@@ -600,9 +610,8 @@ You may wish to save some data in a file from your supervisor program in order t
 
 ---
 
-**Name**
-
-**wb\_supervisor\_simulation\_get\_mode**, **wb\_supervisor\_simulation\_set\_mode** - *get and set the simulation mode*
+##### `wb_supervisor_simulation_get_mode`
+##### `wb_supervisor_simulation_set_mode`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -613,7 +622,9 @@ int wb_supervisor_simulation_get_mode();
 void wb_supervisor_simulation_set_mode(int mode);
 ```
 
-**Description**
+##### Description
+
+*get and set the simulation mode*
 
 The `wb_supervisor_simulation_get_mode` function returns an integer matching with the current simulation mode, i.e., if the simulation is currently paused, is running in real-time, or in fast mode with or without the graphical renderings.
 The macros described in the [table](#simulation-modes) are matching with the return value of this function.
@@ -639,9 +650,8 @@ The current simulation mode can also be modified by the Webots user, when he's c
 
 ---
 
-**Name**
-
-**wb\_supervisor\_load\_world**, **wb\_supervisor\_save\_world** - *Load or save the current world.*
+#### `wb_supervisor_load_world`
+#### `wb_supervisor_save_world`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -652,7 +662,9 @@ void wb_supervisor_load_world(const char *filename);
 bool wb_supervisor_save_world(const char *filename);
 ```
 
-**Description**
+##### Description
+
+*Load or save the current world.*
 
 The `wb_supervisor_load_world` function sends a request to the simulator process, asking it to stop the current simulation and load the world given in argument immediately.
 As a result of changing the current world, the supervisor process and all the robot processes are terminated and the new one are restarted with the new world.
@@ -671,9 +683,7 @@ In this case, a simple save operation is performed.
 
 ---
 
-**Name**
-
-**wb\_supervisor\_simulation\_reset\_physics** - *stop the inertia of all solids in the world and reset the random number generator*
+#### `wb_supervisor_simulation_reset_physics`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -683,7 +693,9 @@ In this case, a simple save operation is performed.
 void wb_supervisor_simulation_reset_physics();
 ```
 
-**Description**
+##### Description
+
+*stop the inertia of all solids in the world and reset the random number generator*
 
 The `wb_supervisor_simulation_reset_physics` function sends a request to the simulator process, asking it to stop the movement of all physics-enabled solids in the world.
 It means that for any [Solid](solid.md) node containing a [Physics](physics.md) node, the linear and angular velocities of the corresponding body are reset to 0, hence the inertia is also zeroed.
@@ -693,9 +705,10 @@ To stop the inertia of a single [Solid](solid.md) node please refer to [this sec
 
 ---
 
-**Name**
-
-**wb\_supervisor\_movie\_start\_recording**, **wb\_supervisor\_movie\_stop\_recording**, **wb\_supervisor\_movie\_is\_ready**, **wb\_supervisor\_movie\_failed** - *export the current simulation into a movie file*
+#### `wb_supervisor_movie_start_recording`
+#### `wb_supervisor_movie_stop_recording`
+#### `wb_supervisor_movie_is_ready`
+#### `wb_supervisor_movie_failed`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -708,7 +721,9 @@ bool wb_supervisor_movie_is_ready();
 bool wb_supervisor_movie_failed();
 ```
 
-**Description**
+##### Description
+
+*export the current simulation into a movie file*
 
 The `wb_supervisor_movie_start_recording` function starts saving the current simulation into a movie file.
 The movie creation process will complete after the `wb_supervisor_movie_stop_recording` function is called.
@@ -735,9 +750,8 @@ After starting a new recording process the returned value is reset to `FALSE`.
 
 ---
 
-**Name**
-
-**wb\_supervisor\_animation\_start\_recording**, **wb\_supervisor\_animation\_stop\_recording** - *export the current simulation into an animation file*
+#### `wb_supervisor_animation_start_recording`
+#### `wb_supervisor_animation_stop_recording`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -748,7 +762,9 @@ bool wb_supervisor_animation_start_recording(const char *filename);
 bool wb_supervisor_animation_stop_recording();
 ```
 
-**Description**
+##### Description
+
+*export the current simulation into an animation file*
 
 The `wb_supervisor_animation_start_recording` function starts saving the current simulation into an animation file.
 The animation creation process will complete after the `wb_supervisor_animation_stop_recording` function is called.
@@ -762,9 +778,9 @@ Both `wb_supervisor_animation_start_recording` and `wb_supervisor_animation_stop
 
 ---
 
-**Name**
-
-**wb\_supervisor\_field\_get\_type**, **wb\_supervisor\_field\_get\_type\_name**, **wb\_supervisor\_field\_get\_count** - *get a handler and more information on a field in a node*
+#### `wb_supervisor_field_get_type`
+#### `wb_supervisor_field_get_type_name`
+#### `wb_supervisor_field_get_count`
 
 [C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -776,7 +792,9 @@ const char *wb_supervisor_field_get_type_name(WbFieldRef field);
 int wb_supervisor_field_get_count(WbFieldRef field);
 ```
 
-**Description**
+##### Description
+
+*get a handler and more information on a field in a node*
 
 The `wb_supervisor_field_get_type` function returns the data type of a field found previously from the `wb_supervisor_node_get_field` function, as a symbolic value.
 If the argument is NULL, the function returns 0.
@@ -795,9 +813,24 @@ These integers can be directly compared with the output of the `Field::getType` 
 
 ---
 
-**Name**
-
-**wb\_supervisor\_field\_get\_sf\_bool**, **wb\_supervisor\_field\_get\_sf\_int32**, **wb\_supervisor\_field\_get\_sf\_float**, **wb\_supervisor\_field\_get\_sf\_vec2f**, **wb\_supervisor\_field\_get\_sf\_vec3f**, **wb\_supervisor\_field\_get\_sf\_rotation**, **wb\_supervisor\_field\_get\_sf\_color**, **wb\_supervisor\_field\_get\_sf\_string**, **wb\_supervisor\_field\_get\_sf\_node**, **wb\_supervisor\_field\_get\_mf\_bool**, **wb\_supervisor\_field\_get\_mf\_int32**, **wb\_supervisor\_field\_get\_mf\_float**, **wb\_supervisor\_field\_get\_mf\_vec2f**, **wb\_supervisor\_field\_get\_mf\_vec3f**, **wb\_supervisor\_field\_get\_mf\_rotation**, **wb\_supervisor\_field\_get\_mf\_color**, **wb\_supervisor\_field\_get\_mf\_string**, **wb\_supervisor\_field\_get\_mf\_node** - *get the value of a field*
+#### `wb_supervisor_field_get_sf_bool`
+#### `wb_supervisor_field_get_sf_int32`
+#### `wb_supervisor_field_get_sf_float`
+#### `wb_supervisor_field_get_sf_vec2f`
+#### `wb_supervisor_field_get_sf_vec3f`
+#### `wb_supervisor_field_get_sf_rotation`
+#### `wb_supervisor_field_get_sf_color`
+#### `wb_supervisor_field_get_sf_string`
+#### `wb_supervisor_field_get_sf_node`
+#### `wb_supervisor_field_get_mf_bool`
+#### `wb_supervisor_field_get_mf_int32`
+#### `wb_supervisor_field_get_mf_float`
+#### `wb_supervisor_field_get_mf_vec2f`
+#### `wb_supervisor_field_get_mf_vec3f`
+#### `wb_supervisor_field_get_mf_rotation`
+#### `wb_supervisor_field_get_mf_color`
+#### `wb_supervisor_field_get_mf_string`
+#### `wb_supervisor_field_get_mf_node`
 
 [C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -824,7 +857,9 @@ const char *wb_supervisor_field_get_mf_string(WbFieldRef field, int index);
 WbNodeRef wb_supervisor_field_get_mf_node(WbFieldRef field, int index);
 ```
 
-**Description**
+##### Description
+
+*get the value of a field*
 
 The `wb_supervisor_field_get_sf_*` functions retrieve the value of a specified single `field` (SF).
 The type of the field has to match the name of the function used, otherwise the return value is undefined (and a warning message is displayed).
@@ -839,9 +874,22 @@ The type of the field has to match the name of the function used and the index s
 
 ---
 
-**Name**
-
-**wb\_supervisor\_field\_set\_sf\_bool**, **wb\_supervisor\_field\_set\_sf\_int32**, **wb\_supervisor\_field\_set\_sf\_float**, **wb\_supervisor\_field\_set\_sf\_vec2f**, **wb\_supervisor\_field\_set\_sf\_vec3f**, **wb\_supervisor\_field\_set\_sf\_rotation**, **wb\_supervisor\_field\_set\_sf\_color**, **wb\_supervisor\_field\_set\_sf\_string**, **wb\_supervisor\_field\_set\_mf\_bool**, **wb\_supervisor\_field\_set\_mf\_int32**, **wb\_supervisor\_field\_set\_mf\_float**, **wb\_supervisor\_field\_set\_mf\_vec2f**, **wb\_supervisor\_field\_set\_mf\_vec3f**, **wb\_supervisor\_field\_set\_mf\_rotation**, **wb\_supervisor\_field\_set\_mf\_color**, **wb\_supervisor\_field\_set\_mf\_string** - *set the value of a field*
+#### `wb_supervisor_field_set_sf_bool`
+#### `wb_supervisor_field_set_sf_int32`
+#### `wb_supervisor_field_set_sf_float`
+#### `wb_supervisor_field_set_sf_vec2f`
+#### `wb_supervisor_field_set_sf_vec3f`
+#### `wb_supervisor_field_set_sf_rotation`
+#### `wb_supervisor_field_set_sf_color`
+#### `wb_supervisor_field_set_sf_string`
+#### `wb_supervisor_field_set_mf_bool`
+#### `wb_supervisor_field_set_mf_int32`
+#### `wb_supervisor_field_set_mf_float`
+#### `wb_supervisor_field_set_mf_vec2f`
+#### `wb_supervisor_field_set_mf_vec3f`
+#### `wb_supervisor_field_set_mf_rotation`
+#### `wb_supervisor_field_set_mf_color`
+#### `wb_supervisor_field_set_mf_string`
 
 [C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -866,7 +914,9 @@ void wb_supervisor_field_set_mf_color(WbFieldRef field, int index, const double 
 void wb_supervisor_field_set_mf_string(WbFieldRef field, int index, const char *value);
 ```
 
-**Description**
+##### Description
+
+*set the value of a field*
 
 The `wb_supervisor_field_set_sf_*` functions assign a value to a specified single `field` (SF).
 The type of the field has to match with the name of the function used, otherwise the value of the field remains unchanged (and a warning message is displayed).
@@ -887,16 +937,22 @@ In order to retrieve the new position of the node, a `wb_robot_step` function ca
 > **Note**: Since Webots 7.4.4, the inertia of a solid is no longer automatically reset when changing its translation or rotation using `wb_supervisor_field_set_sf_vec2f` and `wb_supervisor_field_set_sf_rotation` functions.
 If needed, the user has to explicitly call [this section](#wb_supervisor_node_reset_physics) function.
 
-**Examples**
+##### Examples
 
 The "texture\_change.wbt" world, located in the "projects/samples/howto/worlds" directory, shows how to change a texture from the supervisor while the simulation is running.
 The "soccer.wbt" world, located in the "projects/samples/demos/worlds" directory, provides a simple example for getting and setting fields with the above described functions.
 
 ---
 
-**Name**
-
-**wb\_supervisor\_field\_insert\_mf\_bool**, **wb\_supervisor\_field\_insert\_mf\_int32**, **wb\_supervisor\_field\_insert\_mf\_float**, **wb\_supervisor\_field\_insert\_mf\_vec2f**, **wb\_supervisor\_field\_insert\_mf\_vec3f**, **wb\_supervisor\_field\_insert\_mf\_rotation**, **wb\_supervisor\_field\_insert\_mf\_color**, **wb\_supervisor\_field\_insert\_mf\_string**, **wb\_supervisor\_field\_remove\_mf** - *insert or remove a value in a field*
+#### `wb_supervisor_field_insert_mf_bool`
+#### `wb_supervisor_field_insert_mf_int32`
+#### `wb_supervisor_field_insert_mf_float`
+#### `wb_supervisor_field_insert_mf_vec2f`
+#### `wb_supervisor_field_insert_mf_vec3f`
+#### `wb_supervisor_field_insert_mf_rotation`
+#### `wb_supervisor_field_insert_mf_color`
+#### `wb_supervisor_field_insert_mf_string`
+#### `wb_supervisor_field_remove_mf`
 
 [C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -915,7 +971,9 @@ void wb_supervisor_field_insert_mf_string(WbFieldRef field, int index, const cha
 void wb_supervisor_field_remove_mf(WbFieldRef field, int index);
 ```
 
-**Description**
+##### Description
+
+*insert or remove a value in a field*
 
 The `wb_supervisor_field_insert_mf_*` functions insert an item to a specified multiple `field` (MF).
 The type of the field has to match with the name of the function used, otherwise the field remains unchanged (and a warning message is displayed).
@@ -934,9 +992,8 @@ The `wb_supervisor_field_remove_mf` function removes an item from a specified mu
 
 ---
 
-**Name**
-
-**wb\_supervisor\_field\_import\_mf\_node**, **wb\_supervisor\_field\_import\_mf\_node\_from\_string** - *import a node into an MF\_NODE field (typically a "children" field)*
+#### `wb_supervisor_field_import_mf_node`
+#### `wb_supervisor_field_import_mf_node_from_string`
 
 [C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -947,7 +1004,9 @@ void wb_supervisor_field_import_mf_node(WbFieldRef field, int position, const ch
 void wb_supervisor_field_import_mf_node_from_string(WbFieldRef field, int position, const char *node_string);
 ```
 
-**Description**
+##### Description
+
+*import a node into an MF\_NODE field (typically a "children" field)*
 
 The `wb_supervisor_field_import_mf_node` function imports a Webots node into an MF\_NODE.
 This node should be defined in a `.wbo` file referenced by the `filename` parameter.
@@ -997,9 +1056,9 @@ For example, a device imported into a Robot node doesn't reset the Robot, so the
 
 ---
 
-**Name**
-
-**wb\_supervisor\_virtual\_reality\_headset\_is\_used**, **wb\_supervisor\_virtual\_reality\_headset\_get\_position**, **wb\_supervisor\_virtual\_reality\_headset\_get\_orientation** - *check if a virtual reality headset is used and get its position and orientation*
+#### `wb_supervisor_virtual_reality_headset_is_used`
+#### `wb_supervisor_virtual_reality_headset_get_position`
+#### `wb_supervisor_virtual_reality_headset_get_orientation`
 
 [C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
@@ -1011,7 +1070,9 @@ const double *wb_supervisor_virtual_reality_headset_get_position();
 const double *wb_supervisor_virtual_reality_headset_get_orientation();
 ```
 
-**Description**
+##### Description
+
+*check if a virtual reality headset is used and get its position and orientation*
 
 The `wb_supervisor_virtual_reality_headset_is_used` function returns true if a virtual reality headset is currently used to view the simulation.
 For more information about how to use a virtual reality headset refer to the [User Guide](../guide/computer-peripherals.md#virtual-reality-headset).

--- a/reference/touchsensor.md
+++ b/reference/touchsensor.md
@@ -108,9 +108,11 @@ This approximation usually improves as the `basicTimeStep` ([WorldInfo](worldinf
 
 ### TouchSensor Functions
 
-**Name**
-
-**wb\_touch\_sensor\_enable**, **wb\_touch\_sensor\_disable**, **wb\_touch\_sensor\_get\_sampling\_period**, **wb\_touch\_sensor\_get\_value**, **wb\_touch\_sensor\_get\_values** - *enable, disable and read last touch sensor measurements*
+#### `wb_touch_sensor_enable`
+#### `wb_touch_sensor_disable`
+#### `wb_touch_sensor_get_sampling_period`
+#### `wb_touch_sensor_get_value`
+#### `wb_touch_sensor_get_values`
 
 [C++](cpp-api.md#cpp_touch_sensor) [Java](java-api.md#java_touch_sensor) [Python](python-api.md#python_touch_sensor) [Matlab](matlab-api.md#matlab_touch_sensor) [ROS](ros-api.md)
 
@@ -124,7 +126,9 @@ double wb_touch_sensor_get_value(WbDeviceTag tag);
 const double *wb_touch_sensor_get_values(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*enable, disable and read last touch sensor measurements*
 
 The `wb_touch_sensor_enable` function allows the user to enable touch sensor measurements.
 The `sampling_period` argument specifies the sampling period of the sensor and is expressed in milliseconds.
@@ -144,9 +148,7 @@ This function can be used with a sensor of type "force-3d" exclusively.
 
 ---
 
-**Name**
-
-**wb\_touch\_sensor\_get\_type** - *get the touch sensor type*
+#### `wb_touch_sensor_get_type`
 
 [C++](cpp-api.md#cpp_touch_sensor) [Java](java-api.md#java_touch_sensor) [Python](python-api.md#python_touch_sensor) [Matlab](matlab-api.md#matlab_touch_sensor) [ROS](ros-api.md)
 
@@ -156,7 +158,9 @@ This function can be used with a sensor of type "force-3d" exclusively.
 int wb_touch_sensor_get_type(WbDeviceTag tag);
 ```
 
-**Description**
+##### Description
+
+*get the touch sensor type*
 
 This function allows the user to retrieve the touch sensor type defined by the `type` field.
 If the value of the `type` field is "force" then this function returns WB\_TOUCH\_SENSOR\_FORCE, if it is "force-3d" then it returns WB\_TOUCH\_SENSOR\_FORCE3D and otherwise it returns WB\_TOUCH\_SENSOR\_BUMPER.

--- a/reference/touchsensor.md
+++ b/reference/touchsensor.md
@@ -112,7 +112,7 @@ This approximation usually improves as the `basicTimeStep` ([WorldInfo](worldinf
 
 **wb\_touch\_sensor\_enable**, **wb\_touch\_sensor\_disable**, **wb\_touch\_sensor\_get\_sampling\_period**, **wb\_touch\_sensor\_get\_value**, **wb\_touch\_sensor\_get\_values** - *enable, disable and read last touch sensor measurements*
 
-{[C++](cpp-api.md#cpp_touch_sensor)}, {[Java](java-api.md#java_touch_sensor)}, {[Python](python-api.md#python_touch_sensor)}, {[Matlab](matlab-api.md#matlab_touch_sensor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_touch_sensor) [Java](java-api.md#java_touch_sensor) [Python](python-api.md#python_touch_sensor) [Matlab](matlab-api.md#matlab_touch_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/touch_sensor.h>
@@ -148,7 +148,7 @@ This function can be used with a sensor of type "force-3d" exclusively.
 
 **wb\_touch\_sensor\_get\_type** - *get the touch sensor type*
 
-{[C++](cpp-api.md#cpp_touch_sensor)}, {[Java](java-api.md#java_touch_sensor)}, {[Python](python-api.md#python_touch_sensor)}, {[Matlab](matlab-api.md#matlab_touch_sensor)}, {[ROS](ros-api.md)}
+[C++](cpp-api.md#cpp_touch_sensor) [Java](java-api.md#java_touch_sensor) [Python](python-api.md#python_touch_sensor) [Matlab](matlab-api.md#matlab_touch_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/touch_sensor.h>

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -38,7 +38,7 @@ class TestReferences(unittest.TestCase):
                                     line.strip()):
                                 anchors.append(m.group(1))
                         if line.startswith('#'):
-                            m = re.match(r'^(#*) .*$', line)
+                            m = re.match(r'^(#{1,4}) .*$', line)
                             if m:
                                 title = re.sub(r'^#*', '', line)
                                 anchors.append(slugify(title))

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -38,7 +38,7 @@ class TestReferences(unittest.TestCase):
                                     line.strip()):
                                 anchors.append(m.group(1))
                         if line.startswith('#'):
-                            m = re.match(r'^(#{1,4}) .*$', line)
+                            m = re.match(r'^#{1,4} .*$', line)
                             if m:
                                 title = re.sub(r'^#*', '', line)
                                 anchors.append(slugify(title))

--- a/tests/test_titles.py
+++ b/tests/test_titles.py
@@ -67,7 +67,8 @@ class TestTitles(unittest.TestCase):
     def test_underscores_are_protected(self):
         """Test that titles doesn't contain any unprotected underscore."""
         for t in self.titles:
-            self.assertTrue(re.search(r'[^\\]_', t['title']) is None, msg='%s: Title "%s" contains unprotected underscore(s).' % (t['md'], t['title']))
+            title = re.sub(r'`.+?(?=`)`', '', t['title'])  # Remove code-quoted statements.
+            self.assertTrue(re.search(r'[^\\]_', title) is None, msg='%s: Title "%s" contains unprotected underscore(s).' % (t['md'], t['title']))
 
     def test_words_are_capitalized(self):
         """Test that title words are capitalized."""
@@ -79,6 +80,7 @@ class TestTitles(unittest.TestCase):
         for t in self.titles:
             title = re.sub(r'^#+\s*', '', t['title'])  # Remove the '#'+ suffix.
             title = re.sub(r'".+?(?=")"', '', title)  # Remove double-quoted statements.
+            title = re.sub(r'`.+?(?=`)`', '', title)  # Remove code-quoted statements.
             words = re.split(r'[ :\(\),/\?\']', title)
             for w in range(len(words)):
                 word = words[w]


### PR DESCRIPTION
Partially fix #591 (in prevision to do better later)

Aim: see the API functions in the page index.

Before: https://www.cyberbotics.com/doc/reference/camera
After: https://www.cyberbotics.com/doc/reference/camera?version=enhancement-api-headers