### PR TITLE
Fixed missing units for motor API

### DIFF
--- a/reference/linearmotor.md
+++ b/reference/linearmotor.md
@@ -22,6 +22,7 @@ It defaults to `"linear motor"`.
 
 - The `maxForce` field specifies both the upper limit and the default value for the motor *available force*.
 The *available force* is the force that is available to the motor to perform the requested motions.
+It is expressed in *Newton* (N).
 The `wb_motor_set_available_force` function can be used to change the *available force* at run-time.
-The value of `maxForce` should always be zero or positive (the default is 10).
+The value of `maxForce` should always be zero or positive (the default value is 10 N).
 A small `maxForce` value may result in a motor being unable to move to the target position because of its weight or other external forces.

--- a/reference/motor.md
+++ b/reference/motor.md
@@ -17,7 +17,8 @@ Motor {
 
 ### Description
 
-A [Motor](#motor) node is an abstract node (not instantiated) whose derived classes can be used in a mechanical simulation to power a joint hence producing a motion along, or around, one of its axes.
+A [Motor](#motor) node is an abstract node (not instantiated) whose derived classes are [RotationalMotor](rotationalmotor.md) and [LinearMotor](linearmotor.md).
+These classes can be used in a mechanical simulation to power a joint hence producing a motion along, or around, one of its axes.
 
 A [RotationalMotor](rotationalmotor.md) can power a [HingeJoint](hingejoint.md) (resp. a [Hinge2Joint](hinge2joint.md)) when set inside the `device` (resp. `device` or `device2`) field of these nodes.
 It produces then a rotational motion around the choosen axis.
@@ -26,6 +27,7 @@ Likewise, a [LinearMotor](linearmotor.md) can power a [SliderJoint](hingejoint.m
 ### Field Summary
 
 - The `acceleration` field defines the default acceleration of the P-controller.
+It is expressed in *meter per second squared* for linear motors and in *meter per radian squared* for rotational motors.
 A value of -1 (infinite) means that the acceleration is not limited by the P-controller.
 The acceleration can be changed at run-time with the `wb_motor_set_acceleration` function.
 
@@ -59,6 +61,7 @@ With a small *P*, more simulation steps are needed to reach the target position,
 These fields are described in more detail in the [Motor Limits section](#motor-limits), see below.
 
 - The `maxVelocity` field specifies both the upper limit and the default value for the motor *velocity*.
+It is expressed in *meter per second* for linear motors and in *meter per radian* for rotational motors.
 The *velocity* can be changed at run-time with the `wb_motor_set_velocity` function.
 The value should always be positive (the default is 10).
 
@@ -264,6 +267,7 @@ double wb_motor_get_max_torque(WbDeviceTag tag);
 *change the parameters of the PID-controller*
 
 The `wb_motor_set_position` function specifies a new target position that the PID-controller will attempt to reach using the current velocity, acceleration and motor torque/force parameters.
+The specified position is expressed in *radian* for rotational motors and in *meter* for linear motors.
 This function returns immediately (asynchronous) while the actual motion is carried out in the background by Webots.
 The target position will be reached only if the physics simulation allows it, that means, if the specified motor force is sufficient and the motion is not blocked by obstacles, external forces or the motor's own spring force, etc.
 It is also possible to wait until the [Motor](#motor) reaches the target position (synchronous) like this:
@@ -311,7 +315,8 @@ wb_motor_set_velocity(tag, desired_speed);  // rad/s
 The `wb_motor_get_target_position` function allows the user to get the target position.
 This value matches with the argument given to the last `wb_motor_set_position` function call.
 
-The `wb_motor_set_velocity` function specifies the velocity that motor should reach while moving to the target position.
+The `wb_motor_set_velocity` function specifies the velocity that a motor should reach while moving to the target position.
+The velocity is expressed in *radian per second* for rotational motors and in *meter per second* for linear motors.
 In other words, this means that the motor will accelerate (using the specified acceleration, see below) until the target velocity is reached.
 The velocity argument passed to this function cannot exceed the limit specified in the `maxVelocity` field.
 The specified velocity can be retrieved using the `wb_motor_get_velocity` function.
@@ -319,10 +324,13 @@ The `wb_motor_get_max_velocity` function returns the limit specified in the `max
 Note that if the velocity is not explicitly set using the `wb_motor_set_velocity` function, then the `wb_motor_get_velocity` and `wb_motor_get_max_velocity` functions return the same value.
 
 The `wb_motor_set_acceleration` function specifies the acceleration that the PID-controller should use when trying to reach the specified velocity.
+The acceleration is expressed in *radian per second squared* for rotational motors and in *meter per second squared* for linear motors.
 Note that an infinite acceleration is obtained by passing -1 as the `acc` argument to this function.
 The specified acceleration overwrites the `acceleration` field value and can be retrieved using the `wb_motor_get_acceleration` function.
 
 The `wb_motor_set_available_force` (resp. `wb_motor_set_available_torque`) function specifies the maximum force (resp. torque) that will be available to the motor to carry out the requested motion.
+The force is expressed in *Newton* (N).
+The torque is expressed in *Newton meter* (N\*m).
 The motor force/torque specified with this function cannot exceed the value specified in the `maxForce`/`maxTorque` field.
 The specified force (resp. torque) can be retrieved using the `wb_motor_get_available_force` (resp. `wb_motor_get_available_torque`) function.
 The `wb_motor_get_max_force` (reps. `wb_motor_get_max_torque`) function returns the limit specified in the `maxForce` (resp. `maxTorque`) field.
@@ -334,7 +342,7 @@ With a small *P*, a long time is needed to reach the target position, while too 
 The default value of *P, I* and *D* are specified by the `controlPID` field of the corresponding [Motor](#motor) node.
 
 The `wb_motor_get_[min|max]_position` functions allow to get the values of respectively the `minPosition` and the `maxPosition` fields.
-
+Positions are expressed in *radian* for rotational motors and in *meter* for linear motors.
 ---
 
 #### `wb_motor_enable_force_feedback`
@@ -372,7 +380,8 @@ Note that the first measurement will be available only after the first sampling 
 
 The `wb_motor_get_force_feedback` (resp. `wb_motor_get_torque_feedback`) function returns the most recent motor force (resp. torque) measurement.
 This function measures the amount of motor force (resp. torque) that is currently being used by the motor in order to achieve the desired motion or hold the current position.
-For a "rotational" motor, the returned value is a torque [N\*m]; for a "linear" motor, the value is a force [N].
+For a rotational motor, the returned value is a torque, expressed in *Newton meter* (N\*m).
+For a linear motor, the returned value is a force, expressed in *Newton* (N).
 The returned value is an approximation computed by the physics engine, and therefore it may be inaccurate.
 The returned value normally does not exceed the available motor force (resp. torque) specified with the `wb_motor_set_force` (resp. `wb_motor_set_torque`) function.
 The default value is provided by the `maxForce` (resp. `maxTorque` field).
@@ -419,8 +428,8 @@ This function bypasses the PID-controller and ODE joint motors; it adds the forc
 This allows the user to design a custom controller, for example a PID controller.
 Note that when the `wb_motor_set_force` (resp. `wb_motor_set_torque`) function is invoked, this automatically resets the force previously added by the PID-controller.
 
-In a "rotational" motor, the *torque* parameter specifies the amount of torque [N\*m] that will be applied around the motor rotation axis.
-In a "linear" motor, the *force* parameter specifies the amount of force [N] that will be applied along the sliding axis.
+In a rotational motor, the *torque* parameter specifies the amount of torque expressed in *Newton meter* (N\*m) that will be applied around the motor rotation axis.
+In a linear motor, the *force* parameter specifies the amount of force expressed in *Newton* (N) that will be applied along the sliding axis.
 A positive *force* (resp. *torque*) will move the bodies in the positive direction, which corresponds to the direction of the motor when its position value increases.
 When invoking the `wb_motor_set_force` (resp. `wb_motor_set_torque`) function, the specified *force* (resp. *torque*) parameter cannot exceed the currently available force (resp. torque) of the motor.
 The currently available force (resp. torque) is specified in the `maxForce` (resp. `maxTorque`) field or by calling the `wb_motor_set_available_force` (resp. `wb_motor_set_available_torque`) function.

--- a/reference/motor.md
+++ b/reference/motor.md
@@ -324,7 +324,7 @@ The `wb_motor_get_max_velocity` function returns the limit specified in the `max
 Note that if the velocity is not explicitly set using the `wb_motor_set_velocity` function, then the `wb_motor_get_velocity` and `wb_motor_get_max_velocity` functions return the same value.
 
 The `wb_motor_set_acceleration` function specifies the acceleration that the PID-controller should use when trying to reach the specified velocity.
-The acceleration is expressed in *radian per second squared* (rad/s²) for rotational motors and in *meter per second squared* /m/s²) for linear motors.
+The acceleration is expressed in *radian per second squared* (rad/s²) for rotational motors and in *meter per second squared* (m/s²) for linear motors.
 Note that an infinite acceleration is obtained by passing -1 as the `acc` argument to this function.
 The specified acceleration overwrites the `acceleration` field value and can be retrieved using the `wb_motor_get_acceleration` function.
 

--- a/reference/motor.md
+++ b/reference/motor.md
@@ -27,7 +27,7 @@ Likewise, a [LinearMotor](linearmotor.md) can power a [SliderJoint](hingejoint.m
 ### Field Summary
 
 - The `acceleration` field defines the default acceleration of the P-controller.
-It is expressed in *meter per second squared* for linear motors and in *meter per radian squared* for rotational motors.
+It is expressed in *meter per second squared* (m/s²) for linear motors and in *meter per radian squared* (rad/s²) for rotational motors.
 A value of -1 (infinite) means that the acceleration is not limited by the P-controller.
 The acceleration can be changed at run-time with the `wb_motor_set_acceleration` function.
 
@@ -61,7 +61,7 @@ With a small *P*, more simulation steps are needed to reach the target position,
 These fields are described in more detail in the [Motor Limits section](#motor-limits), see below.
 
 - The `maxVelocity` field specifies both the upper limit and the default value for the motor *velocity*.
-It is expressed in *meter per second* for linear motors and in *meter per radian* for rotational motors.
+It is expressed in *meter per second* (m/s) for linear motors and in *meter per radian* (rad/s) for rotational motors.
 The *velocity* can be changed at run-time with the `wb_motor_set_velocity` function.
 The value should always be positive (the default is 10).
 
@@ -75,16 +75,16 @@ This functionality is not available for [Hinge2Joint](hinge2joint.md) and [Track
 ### Units
 
 The position of a motor corresponds to joint position as defined in [JointParameters](jointparameters.md).
-The position of a rotational motor is expressed in *radians* while the position of a linear motor is expressed in *meters*.
+The position of a rotational motor is expressed in *radians* (rad) while the position of a linear motor is expressed in *meters* (m).
 See [this table](#motor-units):
 
 %figure "Motor Units"
 
-| &nbsp;       | Rotational                   | Linear                    |
-| ------------ | ---------------------------- | ------------------------- |
-| Position     | rad (radians)                | m (meters)                |
-| Velocity     | rad/s (radians / second)     | m/s (meters / second)     |
-| Acceleration | rad/s^2 (radians / second^2) | m/s^2 (meters / second^2) |
+| &nbsp;       | Rotational                 | Linear                  |
+| ------------ | ---------------------------| ----------------------- |
+| Position     | rad (radians)              | m (meters)              |
+| Velocity     | rad/s (radians / second)   | m/s (meters / second)   |
+| Acceleration | rad/s² (radians / second²) | m/s² (meters / second²) |
 
 %end
 
@@ -267,7 +267,7 @@ double wb_motor_get_max_torque(WbDeviceTag tag);
 *change the parameters of the PID-controller*
 
 The `wb_motor_set_position` function specifies a new target position that the PID-controller will attempt to reach using the current velocity, acceleration and motor torque/force parameters.
-The specified position is expressed in *radian* for rotational motors and in *meter* for linear motors.
+The specified position is expressed in *radian* (rad) for rotational motors and in *meter* (m) for linear motors.
 This function returns immediately (asynchronous) while the actual motion is carried out in the background by Webots.
 The target position will be reached only if the physics simulation allows it, that means, if the specified motor force is sufficient and the motion is not blocked by obstacles, external forces or the motor's own spring force, etc.
 It is also possible to wait until the [Motor](#motor) reaches the target position (synchronous) like this:
@@ -316,7 +316,7 @@ The `wb_motor_get_target_position` function allows the user to get the target po
 This value matches with the argument given to the last `wb_motor_set_position` function call.
 
 The `wb_motor_set_velocity` function specifies the velocity that a motor should reach while moving to the target position.
-The velocity is expressed in *radian per second* for rotational motors and in *meter per second* for linear motors.
+The velocity is expressed in *radian per second* (rad/s) for rotational motors and in *meter per second* (m/s) for linear motors.
 In other words, this means that the motor will accelerate (using the specified acceleration, see below) until the target velocity is reached.
 The velocity argument passed to this function cannot exceed the limit specified in the `maxVelocity` field.
 The specified velocity can be retrieved using the `wb_motor_get_velocity` function.
@@ -324,7 +324,7 @@ The `wb_motor_get_max_velocity` function returns the limit specified in the `max
 Note that if the velocity is not explicitly set using the `wb_motor_set_velocity` function, then the `wb_motor_get_velocity` and `wb_motor_get_max_velocity` functions return the same value.
 
 The `wb_motor_set_acceleration` function specifies the acceleration that the PID-controller should use when trying to reach the specified velocity.
-The acceleration is expressed in *radian per second squared* for rotational motors and in *meter per second squared* for linear motors.
+The acceleration is expressed in *radian per second squared* (rad/s²) for rotational motors and in *meter per second squared* /m/s²) for linear motors.
 Note that an infinite acceleration is obtained by passing -1 as the `acc` argument to this function.
 The specified acceleration overwrites the `acceleration` field value and can be retrieved using the `wb_motor_get_acceleration` function.
 
@@ -342,7 +342,7 @@ With a small *P*, a long time is needed to reach the target position, while too 
 The default value of *P, I* and *D* are specified by the `controlPID` field of the corresponding [Motor](#motor) node.
 
 The `wb_motor_get_[min|max]_position` functions allow to get the values of respectively the `minPosition` and the `maxPosition` fields.
-Positions are expressed in *radian* for rotational motors and in *meter* for linear motors.
+Positions are expressed in *radian* (rad) for rotational motors and in *meter* (m) for linear motors.
 ---
 
 #### `wb_motor_enable_force_feedback`

--- a/reference/motor.md
+++ b/reference/motor.md
@@ -80,11 +80,11 @@ See [this table](#motor-units):
 
 %figure "Motor Units"
 
-| &nbsp;       | Rotational                 | Linear                  |
-| ------------ | ---------------------------| ----------------------- |
-| Position     | rad (radians)              | m (meters)              |
-| Velocity     | rad/s (radians / second)   | m/s (meters / second)   |
-| Acceleration | rad/s² (radians / second²) | m/s² (meters / second²) |
+| &nbsp;       | Rotational                          | Linear                           |
+| ------------ | ------------------------------------| ---------------------------------|
+| Position     | rad (radians)                       | m (meters)                       |
+| Velocity     | rad/s (radians per second)          | m/s (meters per second)          |
+| Acceleration | rad/s² (radians per second squared) | m/s² (meters per second squared) |
 
 %end
 

--- a/reference/rotationalmotor.md
+++ b/reference/rotationalmotor.md
@@ -22,6 +22,7 @@ It defaults to `"rotational motor"`.
 
 - The `maxTorque` field specifies both the upper limit and the default value for the motor *available torque*.
 The *available torque* is the torque that is available to the motor to perform the requested motions.
+It is expressed in *Newton meter* (N\*m).
 The `wb_motor_set_available_torque` function can be used to change the *available torque* at run-time.
-The value of `maxTorque` should always be zero or positive (the default is 10).
+The value of `maxTorque` should always be zero or positive (the default value is 10 N\*m).
 A small `maxTorque` value may result in a motor being unable to move to the target position because of its weight or other external forces.


### PR DESCRIPTION
Partial fix for #180 (regarding motors).

Test page: https://cyberbotics.com/doc/reference/motor?version=fix-motor-units