### PR TITLE
`[mM]atlab` to `MATLAB`

### DIFF
--- a/guide/cpp-java-python.md
+++ b/guide/cpp-java-python.md
@@ -17,7 +17,7 @@ graph BT
   Python[[SWIG generated Python API](../reference/python-api.md)] --> CPP
   Ros[[ROS API](../reference/ros-api.md)] --> CPP
     CPP --> C["C API (implemented in libcontroller)"]
-    Matlab[[Matlab API](../reference/matlab-api.md)] --> C
+    MATLAB[[MATLAB API](../reference/matlab-api.md)] --> C
       C --> Webots["Webots (binary interface)"]
 %end
 %end

--- a/guide/general-bugs.md
+++ b/guide/general-bugs.md
@@ -24,7 +24,7 @@ If you experience any problem with NAOqi or Choregraphe in Webots, please report
 
 ### MATLAB and Remote Control Plugins
 
-Matlab controllers produce errors when loading a remote control plugin.
+MATLAB controllers produce errors when loading a remote control plugin.
 This prevent users from performing remote control of real robots from MATLAB.
 This problem arises with both the e-puck and darwin-op remote control plugins.
 

--- a/guide/nao.md
+++ b/guide/nao.md
@@ -218,7 +218,7 @@ You will find some in this folder: "WEBOTS\_HOME/projects/robots/aldebaran/world
 
 #### nao\_matlab.wbt
 
-![nao.wbt.png](images/robots/nao/nao.wbt.png) The "nao\_matlab.wbt" world is an example of programming Webots using the Matlab API.
+![nao.wbt.png](images/robots/nao/nao.wbt.png) The "nao\_matlab.wbt" world is an example of programming Webots using the MATLAB API.
 
 #### nao\_without\_camera.wbt
 

--- a/guide/tutorial-1-your-first-simulation-in-webots-20-minutes.md
+++ b/guide/tutorial-1-your-first-simulation-in-webots-20-minutes.md
@@ -172,9 +172,9 @@ As there is no obstacle, the robot will move forwards for ever.
 Firstly we will create and edit the C controller, then we will link it to the robot.
 
 > **Theory**: A **controller** is a program that defines the behavior of a robot.
-Webots controllers can be written in the following programming languages: C, C++, Java, Python, Matlab, etc.
+Webots controllers can be written in the following programming languages: C, C++, Java, Python, MATLAB, etc.
 Note that C, C++ and Java controllers need to be compiled before they can be run as robot controllers.
-Python and Matlab controllers are interpreted languages so they will run without being compiled.
+Python and MATLAB controllers are interpreted languages so they will run without being compiled.
 The `controller` field of a robot specifies which controller is currently linked with to it.
 Please take notice that a controller can be used by several robots, but a robot can only use one controller at a time.
 

--- a/guide/using-matlab.md
+++ b/guide/using-matlab.md
@@ -15,7 +15,7 @@ In addition, it becomes possible to reuse your existing MATLAB code directly in 
 In order to use MATLAB controllers in Webots, the MATLAB software must be installed (a MATLAB license is required).
 Webots {{ webots.version.full }} supports only MATLAB versions 2015b (64 bits), R2016a, R2016b and R2017a.
 
-Webots must be able to access the "matlab" executable (usually a script) in order to run controller m-files.
+Webots must be able to access the MATLAB executable (usually a script) in order to run controller m-files.
 Webots looks for the "matlab" executable in every directory of your *PATH* (or *Path* on Windows) environment variable.
 Note that this is similar to calling "matlab" from a terminal (or *Command Prompt* on Windows), therefore, if MATLAB can be started from a terminal then it can also be started from Webots.
 

--- a/guide/using-matlab.md
+++ b/guide/using-matlab.md
@@ -15,7 +15,7 @@ In addition, it becomes possible to reuse your existing MATLAB code directly in 
 In order to use MATLAB controllers in Webots, the MATLAB software must be installed (a MATLAB license is required).
 Webots {{ webots.version.full }} supports only MATLAB versions 2015b (64 bits), R2016a, R2016b and R2017a.
 
-Webots must be able to access the MATLAB executable (usually a script) in order to run controller m-files.
+Webots must be able to access the "matlab" executable (usually a script) in order to run controller m-files.
 Webots looks for the "matlab" executable in every directory of your *PATH* (or *Path* on Windows) environment variable.
 Note that this is similar to calling "matlab" from a terminal (or *Command Prompt* on Windows), therefore, if MATLAB can be started from a terminal then it can also be started from Webots.
 

--- a/guide/webots-licenses.md
+++ b/guide/webots-licenses.md
@@ -23,7 +23,7 @@ A 30 day trial version of Webots EDU is available upon request.
 
 Webots MOD is a special license mode in which the simulation software comes free of charge and the users pay only for the modules they need.
 Various modules are available for purchase at different price tags.
-They include special robot models (e.g., NAO, DARwIn-OP, e-puck, Thymio 2, etc.) which can be programmed using different programming languages (e.g., C/C++, Matlab, Python) or interfaces to third party software or hardware, etc.
+They include special robot models (e.g., NAO, DARwIn-OP, e-puck, Thymio 2, etc.) which can be programmed using different programming languages (e.g., C/C++, MATLAB, Python) or interfaces to third party software or hardware, etc.
 They are all described on the Cyberbotics website.
 
 ### Webots Licences Overview

--- a/guide/youbot.md
+++ b/guide/youbot.md
@@ -48,7 +48,7 @@ A small C library called "youbot_control" (and located there: "WEBOTS\_HOME/proj
 
 #### youbot\_matlab.wbt
 
-![youbot.wbt.png](images/robots/youbot/youbot.wbt.png) The same simulation as above, but with a controller written in Matlab.
+![youbot.wbt.png](images/robots/youbot/youbot.wbt.png) The same simulation as above, but with a controller written in MATLAB.
 
 #### tower\_of\_hanoi.wbt
 

--- a/js/viewer.js
+++ b/js/viewer.js
@@ -832,7 +832,7 @@ function applyOOTags(view) {
   var as = view.querySelectorAll('a');
   for (var i = 0; i < as.length; i++) {
     var a = as[i];
-    if (['C++', 'Java', 'Python', 'ROS', 'Matlab'].includes(a.innerText)) {
+    if (['C++', 'Java', 'Python', 'ROS', 'MATLAB'].includes(a.innerText)) {
       a.classList.add('tag');
       if (a.parentNode.tagName.toLowerCase() === 'p' && a.parentNode.classList.length === 0)
         a.parentNode.classList.add('tag-container');

--- a/reference/accelerometer.md
+++ b/reference/accelerometer.md
@@ -42,7 +42,7 @@ This field accepts any value in the interval (0.0, inf).
 #### `wb_accelerometer_get_sampling_period`
 #### `wb_accelerometer_get_values`
 
-[C++](cpp-api.md#cpp_accelerometer) [Java](java-api.md#java_accelerometer) [Python](python-api.md#python_accelerometer) [Matlab](matlab-api.md#matlab_accelerometer) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_accelerometer) [Java](java-api.md#java_accelerometer) [Python](python-api.md#python_accelerometer) [MATLAB](matlab-api.md#matlab_accelerometer) [ROS](ros-api.md)
 
 ```c
 #include <webots/accelerometer.h>

--- a/reference/brake.md
+++ b/reference/brake.md
@@ -17,7 +17,7 @@ The [Brake](#brake) node can be inserted in the `device` field of a [HingeJoint]
 #### `wb_brake_set_damping_constant`
 #### `wb_brake_get_type`
 
-[C++](cpp-api.md#cpp_brake) [Java](java-api.md#java_brake) [Python](python-api.md#python_brake) [Matlab](matlab-api.md#matlab_brake) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_brake) [Java](java-api.md#java_brake) [Python](python-api.md#python_brake) [MATLAB](matlab-api.md#matlab_brake) [ROS](ros-api.md)
 
 ```c
 #include <webots/brake.h>

--- a/reference/camera.md
+++ b/reference/camera.md
@@ -121,8 +121,8 @@ Each time a camera is refreshed, an OpenGL rendering is performed, and the color
 The format of this buffers is BGRA (32 bits).
 We recommend to use the `wb_camera_image_get_*`-like functions to access the buffer because the internal format could change.
 
-> **Note** [Matlab]: The Matlab API uses a language-specific representation of color images consisting of a 3D array of RGB triplets.
-Please look at the [Matlab example](#wb_camera_get_image) in the `wb_camera_get_image` function's description.
+> **Note** [MATLAB]: The MATLAB API uses a language-specific representation of color images consisting of a 3D array of RGB triplets.
+Please look at the [MATLAB example](#wb_camera_get_image) in the `wb_camera_get_image` function's description.
 
 ### Frustum
 
@@ -410,7 +410,7 @@ Here is an example:
 
 <!-- -->
 
-> **Note** [Matlab]: The `wb_camera_get_image` function returns a 3-dimensional array of `uint(8)`.
+> **Note** [MATLAB]: The `wb_camera_get_image` function returns a 3-dimensional array of `uint(8)`.
 The first two dimensions of the array are the width and the height of camera's image, the third being the RGB code: 1 for red, 2 for blue and 3 for green.
 The `wb_camera_get_range_image` function returns a 2-dimensional array of `float('single')`.
 The dimensions of the array are the width and the length of camera's image and the float values are the metric distance values deduced from the OpenGL z-buffer.

--- a/reference/camera.md
+++ b/reference/camera.md
@@ -192,7 +192,7 @@ Then, after closing the window, the overlay will be automatically restored.
 #### `wb_camera_disable`
 #### `wb_camera_get_sampling_period`
 
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [MATLAB](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ```c
 #include <webots/camera.h>
@@ -221,7 +221,7 @@ The `wb_camera_get_sampling_period` function returns the period given to the `wb
 #### `wb_camera_get_max_fov`
 #### `wb_camera_set_fov`
 
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [MATLAB](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ```c
 #include <webots/camera.h>
@@ -249,7 +249,7 @@ The minimum and maximum values for the field of view are defined in this [Zoom](
 #### `wb_camera_get_min_focal_distance`
 #### `wb_camera_set_focal_distance`
 
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [MATLAB](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ```c
 #include <webots/camera.h>
@@ -273,7 +273,7 @@ Note that if the camera device has no [Focus](focus.md) node defined in its `foc
 #### `wb_camera_get_width`
 #### `wb_camera_get_height`
 
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [MATLAB](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ```c
 #include <webots/camera.h>
@@ -292,7 +292,7 @@ These functions return the width and height of a camera image as defined in the 
 
 #### `wb_camera_get_near`
 
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [MATLAB](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ```c
 #include <webots/camera.h>
@@ -314,7 +314,7 @@ This function returns the near parameter of a camera device as defined in the co
 #### `wb_camera_image_get_blue`
 #### `wb_camera_image_get_gray`
 
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [MATLAB](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ```c
 #include <webots/camera.h>
@@ -438,7 +438,7 @@ The dimensions of the array are the width and the length of camera's image and t
 
 #### `wb_camera_save_image`
 
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [MATLAB](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ```c
 #include <webots/camera.h>
@@ -474,7 +474,7 @@ It is -1 in case of failure (unable to open the specified file or unrecognized i
 #### `wb_camera_recognition_get_number_of_objects`
 #### `wb_camera_recognition_get_objects`
 
-[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [Matlab](matlab-api.md#matlab_camera) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_camera) [Java](java-api.md#java_camera) [Python](python-api.md#python_camera) [MATLAB](matlab-api.md#matlab_camera) [ROS](ros-api.md)
 
 ```c
 #include <webots/camera.h>

--- a/reference/compass.md
+++ b/reference/compass.md
@@ -41,7 +41,7 @@ This field accepts any value in the interval (0.0, inf).
 #### `wb_compass_get_sampling_period`
 #### `wb_compass_get_values`
 
-[C++](cpp-api.md#cpp_compass) [Java](java-api.md#java_compass) [Python](python-api.md#python_compass) [Matlab](matlab-api.md#matlab_compass) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_compass) [Java](java-api.md#java_compass) [Python](python-api.md#python_compass) [MATLAB](matlab-api.md#matlab_compass) [ROS](ros-api.md)
 
 ```c
 #include <webots/compass.h>

--- a/reference/connector.md
+++ b/reference/connector.md
@@ -144,7 +144,7 @@ But it is not necessary to add a [Physics](physics.md) node to the [Connector](#
 #### `wb_connector_get_presence_sampling_period`
 #### `wb_connector_get_presence`
 
-[C++](cpp-api.md#cpp_connector) [Java](java-api.md#java_connector) [Python](python-api.md#python_connector) [Matlab](matlab-api.md#matlab_connector) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_connector) [Java](java-api.md#java_connector) [Python](python-api.md#python_connector) [MATLAB](matlab-api.md#matlab_connector) [ROS](ros-api.md)
 
 ```c
 #include <webots/connector.h>
@@ -201,7 +201,7 @@ rotation_aligned := the n-ways rotational angle is within tolerance
 #### `wb_connector_lock`
 #### `wb_connector_unlock`
 
-[C++](cpp-api.md#cpp_connector) [Java](java-api.md#java_connector) [Python](python-api.md#python_connector) [Matlab](matlab-api.md#matlab_connector) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_connector) [Java](java-api.md#java_connector) [Python](python-api.md#python_connector) [MATLAB](matlab-api.md#matlab_connector) [ROS](ros-api.md)
 
 ```c
 #include <webots/connector.h>

--- a/reference/device.md
+++ b/reference/device.md
@@ -15,7 +15,7 @@ This abstract node (not instanciable) represents a robot device (actuator and/or
 
 #### `wb_device_get_model`
 
-[C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [Matlab](matlab-api.md#matlab_device) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [MATLAB](matlab-api.md#matlab_device) [ROS](ros-api.md)
 
 ```c
 #include <webots/device.h>
@@ -35,7 +35,7 @@ This function returns NULL if the WbDeviceTag does not match a valid device, or 
 
 #### `wb_device_get_name`
 
-[C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [Matlab](matlab-api.md#matlab_device) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [MATLAB](matlab-api.md#matlab_device) [ROS](ros-api.md)
 
 ```c
 #include <webots/device.h>
@@ -55,7 +55,7 @@ This function returns NULL if the WbDeviceTag does not match a valid device.
 
 #### `wb_device_get_node_type`
 
-[C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [Matlab](matlab-api.md#matlab_device) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_device) [Java](java-api.md#java_device) [Python](python-api.md#python_device) [MATLAB](matlab-api.md#matlab_device) [ROS](ros-api.md)
 
 ```c
 #include <webots/device.h>

--- a/reference/differentialwheels.md
+++ b/reference/differentialwheels.md
@@ -126,7 +126,7 @@ Unlike the "physics" mode, in the "kinematics" mode the gravity and other forces
 
 #### `wb_differential_wheels_set_speed`
 
-[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [MATLAB](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
 ```c
 #include <webots/differential_wheels.h>
@@ -156,7 +156,7 @@ The `wb_differential_wheels_get_left_speed` and `wb_differential_wheels_get_righ
 #### `wb_differential_wheels_disable_encoders`
 #### `wb_differential_wheels_get_encoders_sampling_period`
 
-[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [MATLAB](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
 ```c
 #include <webots/differential_wheels.h>
@@ -189,7 +189,7 @@ Note that the first encoders values will be available only after the first sampl
 #### `wb_differential_wheels_get_right_encoder`
 #### `wb_differential_wheels_set_encoders`
 
-[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [MATLAB](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
 ```c
 #include <webots/differential_wheels.h>
@@ -212,7 +212,7 @@ Setting the encoders' values will not make the wheels rotate to reach the specif
 
 #### `wb_differential_wheels_get_max_speed`
 
-[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [MATLAB](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
 ```c
 #include <webots/differential_wheels.h>
@@ -230,7 +230,7 @@ The `wb_differential_wheels_get_max_speed` function allows the user to get the v
 
 #### `wb_differential_wheels_get_speed_unit`
 
-[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [Matlab](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_differential_wheels) [Java](java-api.md#java_differential_wheels) [Python](python-api.md#python_differential_wheels) [MATLAB](matlab-api.md#matlab_differential_wheels) [ROS](ros-api.md)
 
 ```c
 #include <webots/differential_wheels.h>

--- a/reference/display.md
+++ b/reference/display.md
@@ -143,7 +143,7 @@ The following standard fonts are available:
 In addition to these fonts, it is possible to add other TrueType fonts file in your `PROJECT_HOME/fonts` directory.
 The default font is `Lucida Console, 8 pixels, with anti-aliasing`.
 
-> **Note** [Matlab]: In the Matlab version of the `wb_display_set_color` function, the `color` argument must be a vector containing the three RGB components: `[RED GREEN BLUE]`.
+> **Note** [MATLAB]: In the MATLAB version of the `wb_display_set_color` function, the `color` argument must be a vector containing the three RGB components: `[RED GREEN BLUE]`.
 Each component must be a value between 0.0 and 1.0.
 For example the vector `[1 0 1]` represents the magenta color.
 
@@ -238,7 +238,7 @@ The `wb_display_fill_oval` function draws an oval having the same properties as 
 
 The `wb_display_fill_polygon` function draws a polygon having the same properties as the polygon drawn by the `wb_display_draw_polygon` function except that it is filled instead of outlined.
 
-> **Note** [Java, Python, Matlab]: The Java, Python and Matlab equivalent of the `wb_display_draw_polygon` and `wb_display_fill_polygon` functions don't have a `size` argument because in these languages the size is determined directly from the `x` and `y` arguments.
+> **Note** [Java, Python, MATLAB]: The Java, Python and MATLAB equivalent of the `wb_display_draw_polygon` and `wb_display_fill_polygon` functions don't have a `size` argument because in these languages the size is determined directly from the `x` and `y` arguments.
 
 ---
 

--- a/reference/display.md
+++ b/reference/display.md
@@ -62,7 +62,7 @@ Then, after closing the window, the overlay will be automatically restored.
 #### `wb_display_get_width`
 #### `wb_display_get_height`
 
-[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [MATLAB](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
 ```c
 #include <webots/display.h>
@@ -84,7 +84,7 @@ These functions return respectively the values of the `width` and `height` field
 #### `wb_display_set_opacity`
 #### `wb_display_set_font`
 
-[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [MATLAB](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
 ```c
 #include <webots/display.h>
@@ -152,7 +152,7 @@ For example the vector `[1 0 1]` represents the magenta color.
 #### `wb_display_attach_camera`
 #### `wb_display_detach_camera`
 
-[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [MATLAB](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
 ```c
 #include <webots/display.h>
@@ -183,7 +183,7 @@ After detaching a camera, the pixels that have not been manually drawn will be t
 #### `wb_display_fill_oval`
 #### `wb_display_fill_polygon`
 
-[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [MATLAB](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
 ```c
 #include <webots/display.h>
@@ -249,7 +249,7 @@ The `wb_display_fill_polygon` function draws a polygon having the same propertie
 #### `wb_display_image_save`
 #### `wb_display_image_delete`
 
-[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [Matlab](matlab-api.md#matlab_display) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_display) [Java](java-api.md#java_display) [Python](python-api.md#python_display) [MATLAB](matlab-api.md#matlab_display) [ROS](ros-api.md)
 
 ```c
 #include <webots/display.h>

--- a/reference/distancesensor.md
+++ b/reference/distancesensor.md
@@ -173,7 +173,7 @@ The ground texture must be placed in a [Plane](plane.md).
 #### `wb_distance_sensor_get_sampling_period`
 #### `wb_distance_sensor_get_value`
 
-[C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [Matlab](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [MATLAB](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/distance_sensor.h>
@@ -206,7 +206,7 @@ Hence, the range of the return value is defined by this lookup table.
 #### `wb_distance_sensor_get_min_value`
 #### `wb_distance_sensor_get_aperture`
 
-[C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [Matlab](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [MATLAB](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/distance_sensor.h>
@@ -232,7 +232,7 @@ The `wb_distance_sensor_get_aperture` function returns the aperture of the dista
 
 #### `wb_distance_sensor_get_type`
 
-[C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [Matlab](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_distance_sensor) [Java](java-api.md#java_distance_sensor) [Python](python-api.md#python_distance_sensor) [MATLAB](matlab-api.md#matlab_distance_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/distance_sensor.h>

--- a/reference/emitter.md
+++ b/reference/emitter.md
@@ -79,7 +79,7 @@ In addition it is highly recommended to choose -1 for the baudRate, in order to 
 
 #### `wb_emitter_send`
 
-[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [MATLAB](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
 ```c
 #include <webots/emitter.h>
@@ -148,7 +148,7 @@ Here is an example of sending a Java string in a way that is compatible with a C
 #### `wb_emitter_set_channel`
 #### `wb_emitter_get_channel`
 
-[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [MATLAB](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
 ```c
 #include <webots/emitter.h>
@@ -175,7 +175,7 @@ The `wb_emitter_get_channel` function returns the current channel number of the 
 #### `wb_emitter_set_range`
 #### `wb_emitter_get_range`
 
-[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [MATLAB](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
 ```c
 #include <webots/emitter.h>
@@ -199,7 +199,7 @@ For both the `wb_emitter_set_range` and `emitter_get_range` functions, a value o
 
 #### `wb_emitter_get_buffer_size`
 
-[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [Matlab](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_emitter) [Java](java-api.md#java_emitter) [Python](python-api.md#python_emitter) [MATLAB](matlab-api.md#matlab_emitter) [ROS](ros-api.md)
 
 ```c
 #include <webots/emitter.h>

--- a/reference/gps.md
+++ b/reference/gps.md
@@ -52,7 +52,7 @@ This field accepts any value in the interval (0.0, inf).
 #### `wb_gps_get_values`
 #### `wb_gps_get_speed`
 
-[C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [Matlab](matlab-api.md#matlab_gps) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [MATLAB](matlab-api.md#matlab_gps) [ROS](ros-api.md)
 
 ```c
 #include <webots/gps.h>
@@ -96,7 +96,7 @@ If these values are needed for a longer period they must be copied.
 
 #### `wb_gps_get_coordinate_system`
 
-[C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [Matlab](matlab-api.md#matlab_gps) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [MATLAB](matlab-api.md#matlab_gps) [ROS](ros-api.md)
 
 ```c
 #include <webots/gps.h>
@@ -115,7 +115,7 @@ If the value of the `gpsCoordinateSystem` field is "local" then this function re
 
 #### `wb_gps_convert_to_degrees_minutes_seconds`
 
-[C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [Matlab](matlab-api.md#matlab_gps) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_gps) [Java](java-api.md#java_gps) [Python](python-api.md#python_gps) [MATLAB](matlab-api.md#matlab_gps) [ROS](ros-api.md)
 
 ```c
 #include <webots/gps.h>

--- a/reference/gyro.md
+++ b/reference/gyro.md
@@ -39,7 +39,7 @@ This field accepts any value in the interval (0.0, inf).
 #### `wb_gyro_get_sampling_period`
 #### `wb_gyro_get_values`
 
-[C++](cpp-api.md#cpp_gyro) [Java](java-api.md#java_gyro) [Python](python-api.md#python_gyro) [Matlab](matlab-api.md#matlab_gyro) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_gyro) [Java](java-api.md#java_gyro) [Python](python-api.md#python_gyro) [MATLAB](matlab-api.md#matlab_gyro) [ROS](ros-api.md)
 
 ```c
 #include <webots/gyro.h>

--- a/reference/inertialunit.md
+++ b/reference/inertialunit.md
@@ -58,7 +58,7 @@ This field accepts any value in the interval (0.0, inf).
 #### `wb_inertial_unit_get_sampling_period`
 #### `wb_inertial_unit_get_roll_pitch_yaw`
 
-[C++](cpp-api.md#cpp_inertial_unit) [Java](java-api.md#java_inertial_unit) [Python](python-api.md#python_inertial_unit) [Matlab](matlab-api.md#matlab_inertial_unit) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_inertial_unit) [Java](java-api.md#java_inertial_unit) [Python](python-api.md#python_inertial_unit) [MATLAB](matlab-api.md#matlab_inertial_unit) [ROS](ros-api.md)
 
 ```c
 #include <webots/inertial_unit.h>

--- a/reference/joystick.md
+++ b/reference/joystick.md
@@ -16,7 +16,7 @@ In order to get the `Joystick` instance, you should call the `getJoystick` funct
 #### `wb_joystick_disable`
 #### `wb_joystick_get_sampling_period`
 
-[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [MATLAB](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>
@@ -44,7 +44,7 @@ The `wb_joystick_get_sampling_period` function returns the value previously pass
 
 #### `wb_joystick_is_connected`
 
-[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [MATLAB](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>
@@ -62,7 +62,7 @@ Once the joystick is enabled, this function can be used to check if a free joyst
 
 #### `wb_joystick_get_model`
 
-[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [MATLAB](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>
@@ -83,7 +83,7 @@ The returned model of the joystick may looks like: `Logitech G29 Driving Force R
 #### `wb_joystick_get_number_of_axes`
 #### `wb_joystick_get_axis_value`
 
-[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [MATLAB](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>
@@ -104,7 +104,7 @@ The `wb_joystick_get_axis_value` function returns the current value of the axis 
 
 #### `wb_joystick_get_pressed_button`
 
-[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [MATLAB](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>
@@ -131,7 +131,7 @@ On macOS, only the first 12 buttons and first 2 axes of the joystick are taken i
 #### `wb_joystick_set_auto_centering_gain`
 #### `wb_joystick_set_resistance_gain`
 
-[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [Matlab](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_joystick) [Java](java-api.md#java_joystick) [Python](python-api.md#python_joystick) [MATLAB](matlab-api.md#matlab_joystick) [ROS](ros-api.md)
 
 ```c
 #include <webots/joystick.h>

--- a/reference/keyboard.md
+++ b/reference/keyboard.md
@@ -13,7 +13,7 @@ In order to get the `Keyboard` instance, you should call the `getKeyboard` funct
 #### `wb_keyboard_get_sampling_period`
 #### `wb_keyboard_get_key`
 
-[C++](cpp-api.md#cpp_keyboard) [Java](java-api.md#java_keyboard) [Python](python-api.md#python_keyboard) [Matlab](matlab-api.md#matlab_keyboard) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_keyboard) [Java](java-api.md#java_keyboard) [Python](python-api.md#python_keyboard) [MATLAB](matlab-api.md#matlab_keyboard) [ROS](ros-api.md)
 
 ```c
 #include <webots/keyboard.h>

--- a/reference/led.md
+++ b/reference/led.md
@@ -40,7 +40,7 @@ If the `color` list contains a single color, then the LED is monochromatic, and 
 #### `wb_led_set`
 #### `wb_led_get`
 
-[C++](cpp-api.md#cpp_led) [Java](java-api.md#java_led) [Python](python-api.md#python_led) [Matlab](matlab-api.md#matlab_led) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_led) [Java](java-api.md#java_led) [Python](python-api.md#python_led) [MATLAB](matlab-api.md#matlab_led) [ROS](ros-api.md)
 
 ```c
 #include <webots/led.h>

--- a/reference/lidar.md
+++ b/reference/lidar.md
@@ -139,7 +139,7 @@ The same comment applies to the horizontal resolution, the internal depth camera
 #### `wb_lidar_disable`
 #### `wb_lidar_get_sampling_period`
 
-[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [MATLAB](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -167,7 +167,7 @@ The `wb_lidar_get_sampling_period` function returns the period given into the `w
 #### `wb_lidar_disable_point_cloud`
 #### `wb_lidar_is_point_cloud_enabled`
 
-[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [MATLAB](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -195,7 +195,7 @@ First the lidar should be enabled using the `wb_lidar_enable` function.
 #### `wb_lidar_get_range_image`
 #### `wb_lidar_get_layer_range_image`
 
-[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [MATLAB](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -234,7 +234,7 @@ Their content are identical but their handling is of course different.
 #### `wb_lidar_get_layer_point_cloud`
 #### `wb_lidar_get_number_of_points`
 
-[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [MATLAB](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -267,7 +267,7 @@ The `wb_lidar_get_number_of_points` function returns the total number of points 
 #### `wb_lidar_get_frequency`
 #### `wb_lidar_set_frequency`
 
-[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [MATLAB](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -290,7 +290,7 @@ The `frequency` argument should be in the range [minFrequency; maxFrequency].
 #### `wb_lidar_get_horizontal_resolution`
 #### `wb_lidar_get_number_of_layers`
 
-[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [MATLAB](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -312,7 +312,7 @@ The `wb_lidar_get_number_of_layers` function returns the number of layers of the
 #### `wb_lidar_get_min_frequency`
 #### `wb_lidar_get_max_frequency`
 
-[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [MATLAB](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -332,7 +332,7 @@ The `wb_lidar_get_min_frequency` and `wb_lidar_get_max_frequency` functions retu
 #### `wb_lidar_get_fov`
 #### `wb_lidar_get_vertical_fov`
 
-[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [MATLAB](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>
@@ -354,7 +354,7 @@ The `wb_lidar_get_vertical_fov` function returns the vertical field of view of t
 #### `wb_lidar_get_min_range`
 #### `wb_lidar_get_max_range`
 
-[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [Matlab](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_lidar) [Java](java-api.md#java_lidar) [Python](python-api.md#python_lidar) [MATLAB](matlab-api.md#matlab_lidar) [ROS](ros-api.md)
 
 ```c
 #include <webots/lidar.h>

--- a/reference/lightsensor.md
+++ b/reference/lightsensor.md
@@ -125,7 +125,7 @@ Finally, if the sensor's `lookupTable` is filled with correct calibration data, 
 #### `wb_light_sensor_get_sampling_period`
 #### `wb_light_sensor_get_value`
 
-[C++](cpp-api.md#cpp_light_sensor) [Java](java-api.md#java_light_sensor) [Python](python-api.md#python_light_sensor) [Matlab](matlab-api.md#matlab_light_sensor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_light_sensor) [Java](java-api.md#java_light_sensor) [Python](python-api.md#python_light_sensor) [MATLAB](matlab-api.md#matlab_light_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/light_sensor.h>

--- a/reference/matlab-api.md
+++ b/reference/matlab-api.md
@@ -1,6 +1,6 @@
 ## MATLAB API
 
-The following tables describe the Matlab functions.
+The following tables describe the MATLAB functions.
 
 %api "matlab_accelerometer"
 

--- a/reference/matlab-api.md
+++ b/reference/matlab-api.md
@@ -1,4 +1,4 @@
-## Matlab API
+## MATLAB API
 
 The following tables describe the Matlab functions.
 

--- a/reference/menu.md
+++ b/reference/menu.md
@@ -124,6 +124,6 @@
     - [C++ API](cpp-api.md)
     - [Java API](java-api.md)
     - [Python API](python-api.md)
-    - [Matlab API](matlab-api.md)
+    - [MATLAB API](matlab-api.md)
     - [ROS API](ros-api.md)
 - [Glossary](glossary.md)

--- a/reference/motion.md
+++ b/reference/motion.md
@@ -5,7 +5,7 @@
 #### `wbu_motion_new`
 #### `wbu_motion_delete`
 
-[C++](cpp-api.md#cpp_motion) [Java](java-api.md#java_motion) [Python](python-api.md#python_motion) [Matlab](matlab-api.md#matlab_motion)
+[C++](cpp-api.md#cpp_motion) [Java](java-api.md#java_motion) [Python](python-api.md#python_motion) [MATLAB](matlab-api.md#matlab_motion)
 
 ```c
 #include <webots/utils/motion.h>
@@ -51,7 +51,7 @@ if (! walk->isValid()) {
 #### `wbu_motion_set_loop`
 #### `wbu_motion_set_reverse`
 
-[C++](cpp-api.md#cpp_motion) [Java](java-api.md#java_motion) [Python](python-api.md#python_motion) [Matlab](matlab-api.md#matlab_motion)
+[C++](cpp-api.md#cpp_motion) [Java](java-api.md#java_motion) [Python](python-api.md#python_motion) [MATLAB](matlab-api.md#matlab_motion)
 
 ```c
 #include <webots/utils/motion.h>
@@ -112,7 +112,7 @@ By default, the *loop mode* and *reverse mode* of motions are `false`.
 #### `wbu_motion_get_time`
 #### `wbu_motion_set_time`
 
-[C++](cpp-api.md#cpp_motion) [Java](java-api.md#java_motion) [Python](python-api.md#python_motion) [Matlab](matlab-api.md#matlab_motion)
+[C++](cpp-api.md#cpp_motion) [Java](java-api.md#java_motion) [Python](python-api.md#python_motion) [MATLAB](matlab-api.md#matlab_motion)
 
 ```c
 #include <webots/utils/motion.h>

--- a/reference/motor.md
+++ b/reference/motor.md
@@ -236,7 +236,7 @@ If a more specific or accurate model is needed, it can be implemented in the rob
 #### `wb_motor_get_available_torque`
 #### `wb_motor_get_max_torque`
 
-[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [MATLAB](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
 ```c
 #include <webots/motor.h>
@@ -346,7 +346,7 @@ The `wb_motor_get_[min|max]_position` functions allow to get the values of respe
 #### `wb_motor_get_torque_feedback_sampling_period`
 #### `wb_motor_disable_torque_feedback`
 
-[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [MATLAB](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
 ```c
 #include <webots/motor.h>
@@ -401,7 +401,7 @@ The `wb_motor_get_force_feedback_sampling_period` (resp. `wb_motor_get_torque_fe
 #### `wb_motor_set_force`
 #### `wb_motor_set_torque`
 
-[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [MATLAB](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
 ```c
 #include <webots/motor.h>
@@ -435,7 +435,7 @@ The example in "projects/samples/howto/worlds/force\_control.wbt" demonstrates t
 
 #### `wb_motor_get_type`
 
-[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [Matlab](matlab-api.md#matlab_motor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_motor) [Java](java-api.md#java_motor) [Python](python-api.md#python_motor) [MATLAB](matlab-api.md#matlab_motor) [ROS](ros-api.md)
 
 ```c
 #include <webots/motor.h>

--- a/reference/motor.md
+++ b/reference/motor.md
@@ -159,7 +159,7 @@ wb_motor_set_velocity(motor, 6.28);  // 1 rotation per second
 It is implemented in the C99 specifications as well as in C++.
 In Java, this value is defined as `Double.POSITIVE_INFINITY`.
 In Python, you should use `float('inf')`.
-Finally, in Matlab you should use the `inf` constant.
+Finally, in MATLAB you should use the `inf` constant.
 
 ### Force and Torque Control
 
@@ -306,7 +306,7 @@ wb_motor_set_velocity(tag, desired_speed);  // rad/s
 
 <!-- -->
 
-> **Note** [Matlab]: In MATLAB use `inf` instead of INFINITY.
+> **Note** [MATLAB]: In MATLAB use `inf` instead of INFINITY.
 
 The `wb_motor_get_target_position` function allows the user to get the target position.
 This value matches with the argument given to the last `wb_motor_set_position` function call.

--- a/reference/mouse.md
+++ b/reference/mouse.md
@@ -40,7 +40,7 @@ These values may be `NaN` if not applicable, for example when the mouse is point
 #### `wb_mouse_get_sampling_period`
 #### `wb_mouse_get_key`
 
-[C++](cpp-api.md#cpp_mouse) [Java](java-api.md#java_mouse) [Python](python-api.md#python_mouse) [Matlab](matlab-api.md#matlab_mouse) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_mouse) [Java](java-api.md#java_mouse) [Python](python-api.md#python_mouse) [MATLAB](matlab-api.md#matlab_mouse) [ROS](ros-api.md)
 
 ```c
 #include <webots/mouse.h>

--- a/reference/nodes-and-functions.md
+++ b/reference/nodes-and-functions.md
@@ -11,4 +11,4 @@ For example, the Webots [WorldInfo](worldinfo.md) and [Sphere](sphere.md) nodes 
 This manual covers all the functions of the controller API, necessary to program robots.
 The C prototypes of these functions are described under the *SYNOPSIS* tag.
 The prototypes for the other languages are available through hyperlinks or directly in [this chapter](other-apis.md).
-The language-related particularities mentioned under the label called *C++ Note, Java Note, Python Note, Matlab Note*, etc.
+The language-related particularities mentioned under the label called *C++ Note, Java Note, Python Note, MATLAB Note*, etc.

--- a/reference/other-apis.md
+++ b/reference/other-apis.md
@@ -11,5 +11,5 @@ Generally speaking, each C function has one and only one counterpart for in a sp
 - [C++ API](cpp-api.md)
 - [Java API](java-api.md)
 - [Python API](python-api.md)
-- [Matlab API](matlab-api.md)
+- [MATLAB API](matlab-api.md)
 - [ROS API](ros-api.md)

--- a/reference/pen.md
+++ b/reference/pen.md
@@ -104,6 +104,6 @@ wb_pen_set_ink_color(pen,0xF01010,0.9);
 
 The above statement will change the ink color of the indicated pen to some red color.
 
-> **Note** [Matlab]: In the Matlab version of the `wb_pen_set_ink_color` function, the `color` argument must be a vector containing the three RGB components: `[RED GREEN BLUE]`.
+> **Note** [MATLAB]: In the MATLAB version of the `wb_pen_set_ink_color` function, the `color` argument must be a vector containing the three RGB components: `[RED GREEN BLUE]`.
 Each component must be a value between 0.0 and 1.0.
 For example the vector `[1 0 1]` represents the magenta color.

--- a/reference/pen.md
+++ b/reference/pen.md
@@ -61,7 +61,7 @@ It is also switchable from the pen API, using the `wb_pen_write` function.
 
 #### `wb_pen_write`
 
-[C++](cpp-api.md#cpp_pen) [Java](java-api.md#java_pen) [Python](python-api.md#python_pen) [Matlab](matlab-api.md#matlab_pen) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_pen) [Java](java-api.md#java_pen) [Python](python-api.md#python_pen) [MATLAB](matlab-api.md#matlab_pen) [ROS](ros-api.md)
 
 ```c
 #include <webots/pen.h>
@@ -80,7 +80,7 @@ If the `write` parameter is *true*, the specified `tag` device will write; if `w
 
 #### `wb_pen_set_ink_color`
 
-[C++](cpp-api.md#cpp_pen) [Java](java-api.md#java_pen) [Python](python-api.md#python_pen) [Matlab](matlab-api.md#matlab_pen) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_pen) [Java](java-api.md#java_pen) [Python](python-api.md#python_pen) [MATLAB](matlab-api.md#matlab_pen) [ROS](ros-api.md)
 
 ```c
 #include <webots/pen.h>

--- a/reference/positionsensor.md
+++ b/reference/positionsensor.md
@@ -28,7 +28,7 @@ This field accepts any value in the interval (0.0, inf).
 #### `wb_position_sensor_get_value`
 #### `wb_position_sensor_get_type`
 
-[C++](cpp-api.md#cpp_position_sensor) [Java](java-api.md#java_position_sensor) [Python](python-api.md#python_position_sensor) [Matlab](matlab-api.md#matlab_position_sensor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_position_sensor) [Java](java-api.md#java_position_sensor) [Python](python-api.md#python_position_sensor) [MATLAB](matlab-api.md#matlab_position_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/position_sensor.h>

--- a/reference/radar.md
+++ b/reference/radar.md
@@ -134,7 +134,7 @@ The power returned by the target is computed using the following formulas:
 #### `wb_radar_disable`
 #### `wb_radar_get_sampling_period`
 
-[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [MATLAB](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
 ```c
 #include <webots/radar.h>
@@ -161,7 +161,7 @@ The `wb_radar_get_sampling_period` function returns the period given into the `w
 #### `wb_radar_get_min_range`
 #### `wb_radar_get_max_range`
 
-[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [MATLAB](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
 ```c
 #include <webots/radar.h>
@@ -181,7 +181,7 @@ These functions allow the controller to get the value of the minimum and maximum
 #### `wb_radar_get_horizontal_fov`
 #### `wb_radar_get_vertical_fov`
 
-[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [MATLAB](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
 ```c
 #include <webots/radar.h>
@@ -200,7 +200,7 @@ These functions allow the controller to get the value of the horizontal and vert
 
 #### `wb_radar_get_number_of_targets`
 
-[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [MATLAB](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
 ```c
 #include <webots/radar.h>
@@ -218,7 +218,7 @@ This function allows the controller to get the number of targets currently seen 
 
 #### `wb_radar_get_targets`
 
-[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [Matlab](matlab-api.md#matlab_radar) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_radar) [Java](java-api.md#java_radar) [Python](python-api.md#python_radar) [MATLAB](matlab-api.md#matlab_radar) [ROS](ros-api.md)
 
 ```c
 #include <webots/radar.h>

--- a/reference/rangefinder.md
+++ b/reference/rangefinder.md
@@ -100,7 +100,7 @@ Then, after closing the window, the overlay will be automatically restored.
 #### `wb_range_finder_disable`
 #### `wb_range_finder_get_sampling_period`
 
-[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [MATLAB](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>
@@ -126,7 +126,7 @@ The `wb_range_finder_get_sampling_period` function returns the period given into
 
 #### `wb_range_finder_get_fov`
 
-[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [MATLAB](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>
@@ -145,7 +145,7 @@ These functions allow the controller to get the value of the field of view (fov)
 #### `wb_range_finder_get_width`
 #### `wb_range_finder_get_height`
 
-[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [MATLAB](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>
@@ -165,7 +165,7 @@ These functions return the width and height of a range-finder image as defined i
 #### `wb_range_finder_get_min_range`
 #### `wb_range_finder_get_max_range`
 
-[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [MATLAB](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>
@@ -185,7 +185,7 @@ These functions return the minRange and maxRange parameters of a range-finder de
 #### `wb_range_finder_get_range_image`
 #### `wb_range_finder_image_get_depth`
 
-[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [MATLAB](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>
@@ -226,7 +226,7 @@ Their content are identical but their handling is of course different.
 
 #### `wb_range_finder_save_image`
 
-[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [Matlab](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_range_finder) [Java](java-api.md#java_range_finder) [Python](python-api.md#python_range_finder) [MATLAB](matlab-api.md#matlab_range_finder) [ROS](ros-api.md)
 
 ```c
 #include <webots/range_finder.h>

--- a/reference/receiver.md
+++ b/reference/receiver.md
@@ -196,7 +196,7 @@ Here is an example for getting the data:
 
 <!-- -->
 
-> **Note** [Matlab]: The Matlab `wb_receiver_get_data` function returns a MATLAB *libpointer*.
+> **Note** [MATLAB]: The MATLAB `wb_receiver_get_data` function returns a MATLAB *libpointer*.
 The receiving code is responsible for extracting the data from the *libpointer* using MATLAB's `setdatatype` and `get` functions.
 Here is an example on how to send and receive a 2x3 MATLAB matrix.
 

--- a/reference/receiver.md
+++ b/reference/receiver.md
@@ -67,7 +67,7 @@ The noise is not dependent on the distance between emitter-receiver.
 #### `wb_receiver_disable`
 #### `wb_receiver_get_sampling_period`
 
-[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [MATLAB](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
 ```c
 #include <webots/receiver.h>
@@ -98,7 +98,7 @@ The `wb_receiver_get_sampling_period` function returns the period given into the
 #### `wb_receiver_get_queue_length`
 #### `wb_receiver_next_packet`
 
-[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [MATLAB](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
 ```c
 #include <webots/receiver.h>
@@ -160,7 +160,7 @@ Making assumptions based on timing will result in code that is not robust.
 #### `wb_receiver_get_data`
 #### `wb_receiver_get_data_size`
 
-[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [MATLAB](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
 ```c
 #include <webots/receiver.h>
@@ -242,7 +242,7 @@ More sophisticated data typed must be accessed explicitly using `setdatatype` an
 #### `wb_receiver_get_signal_strength`
 #### `wb_receiver_get_emitter_direction`
 
-[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [MATLAB](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
 ```c
 #include <webots/receiver.h>
@@ -278,7 +278,7 @@ It is illegal to call this function if the receiver's queue is empty (i.e. when 
 #### `wb_receiver_set_channel`
 #### `wb_receiver_get_channel`
 
-[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [Matlab](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_receiver) [Java](java-api.md#java_receiver) [Python](python-api.md#python_receiver) [MATLAB](matlab-api.md#matlab_receiver) [ROS](ros-api.md)
 
 ```c
 #include <webots/receiver.h>

--- a/reference/robot.md
+++ b/reference/robot.md
@@ -116,7 +116,7 @@ Asynchronous controllers may also be recommended for networked simulations invol
 #### `wb_robot_init`
 #### `wb_robot_cleanup`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -216,7 +216,7 @@ int main() {
 
 #### `wb_robot_get_device`
 
-[Matlab](matlab-api.md#matlab_robot)
+[MATLAB](matlab-api.md#matlab_robot)
 
 ```c
 #include <webots/robot.h>
@@ -318,7 +318,7 @@ Instead, C and Matlab users should use [`wb_robot_get_device`](#wb_robot_get_dev
 
 #### `wb_robot_get_device_by_index`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -367,7 +367,7 @@ for(i=0; i<n_devices; i++) {
 #### `wb_robot_get_battery_sampling_period`
 #### `wb_robot_battery_sensor_get_value`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -396,7 +396,7 @@ The `wb_robot_get_battery_sampling_period` function returns the period given int
 
 #### `wb_robot_get_basic_time_step`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -414,7 +414,7 @@ This function returns the value of the `basicTimeStep` field of the [WorldInfo](
 
 #### `wb_robot_get_mode`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -449,7 +449,7 @@ The integers can be compared to the following enumeration items:
 
 #### `wb_robot_get_name`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -472,7 +472,7 @@ This sample world is located in the "projects/samples/demos/worlds" directory of
 
 #### `wb_robot_get_model`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -494,7 +494,7 @@ The string returned should not be deallocated, as it was allocated by the "libCo
 
  - *set the data defined in the robot node*
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -515,7 +515,7 @@ The `wb_robot_set_custom_data` function set the string contained in the `customD
 
 #### `wb_robot_get_type`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/nodes.h>
@@ -534,7 +534,7 @@ This function returns the type of the current mode (WB\_NODE\_ROBOT, WB\_NODE\_S
 
 #### `wb_robot_get_project_path`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -555,7 +555,7 @@ It should not be deallocated.
 
 #### `wb_robot_get_world_path`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -576,7 +576,7 @@ It should not be deallocated.
 #### `wb_robot_get_controller_name`
 #### `wb_robot_get_controller_arguments`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -595,7 +595,7 @@ These functions return the content of respectively the Robot::controller and the
 
 #### `wb_robot_get_synchronization`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -613,7 +613,7 @@ This function returns the boolean value corresponding to the synchronization fie
 
 #### `wb_robot_get_time`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot.h>
@@ -699,7 +699,7 @@ Users unfamiliar with the mutex concept may wish to consult a reference on multi
 #### `wb_robot_wwi_send`
 #### `wb_robot_wwi_send_text`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/utils/default_robot_window.h>
@@ -730,7 +730,7 @@ The message is received using the `webots.window("<robot window name>").receive`
 
 #### `wb_robot_window_custom_function`
 
-[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [Matlab](matlab-api.md#matlab_robot) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_robot) [Java](java-api.md#java_robot) [Python](python-api.md#python_robot) [MATLAB](matlab-api.md#matlab_robot) [ROS](ros-api.md)
 
 ```c
 #include <webots/robot_window.h>

--- a/reference/robot.md
+++ b/reference/robot.md
@@ -308,7 +308,7 @@ For example, if a robot contains a [DistanceSensor](distancesensor.md) node whos
 If the specified device is not found, the function returns `NULL` in C++, `null` in Java or the `none` in Python.
 
 > **Note**: These functions are not available in the C and MATLAB APIs.
-Instead, C and Matlab users should use [`wb_robot_get_device`](#wb_robot_get_device) function.
+Instead, C and MATLAB users should use [`wb_robot_get_device`](#wb_robot_get_device) function.
 
 ##### See Also
 
@@ -724,7 +724,7 @@ The message is sent using the `webots.window("<robot window name>").send` method
 The `wb_robot_window_send` and `wb_robot_wwi_send_text` functions allow a robot controller to send a message to a Javascript function running in the HTML robot window.
 The message is received using the `webots.window("<robot window name>").receive` method of the Webots Javascript API.
 
-> **note** [Java, Python, Matlab, ROS]: `wb_robot_wwi_receive` and `wb_robot_window_send` functions are not available in the Java, Python, Matlab, or ROS API.
+> **note** [Java, Python, MATLAB, ROS]: `wb_robot_wwi_receive` and `wb_robot_window_send` functions are not available in the Java, Python, MATLAB, or ROS API.
 
 ---
 
@@ -776,4 +776,4 @@ void *wbw_robot_window_custom_function(void *arg) {
 }
 ```
 
-> **Note** [Java, Python, Matlab]: Given that the native robot window can only be implemented for C/C++ controllers, `wb_robot_window_custom_function` is not available in Java, Python or Matlab API.
+> **Note** [Java, Python, MATLAB]: Given that the native robot window can only be implemented for C/C++ controllers, `wb_robot_window_custom_function` is not available in Java, Python or MATLAB API.

--- a/reference/speaker.md
+++ b/reference/speaker.md
@@ -16,7 +16,7 @@ It can be used to play sounds and perform text-to-speech from the controller API
 
 #### `wb_speaker_play_sound`
 
-[C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [Matlab](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [MATLAB](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
 
 ```c
 #include <webots/speaker.h>
@@ -56,7 +56,7 @@ If not found there and if the robot is a PROTO, it will be searched relatively t
 
 #### `wb_speaker_stop`
 
-[C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [Matlab](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [MATLAB](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
 
 ```c
 #include <webots/speaker.h>
@@ -82,7 +82,7 @@ It is possible to stop all the sounds currently playing in a speaker by setting 
 #### `wb_speaker_get_language`
 #### `wb_speaker_speak`
 
-[C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [Matlab](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_speaker) [Java](java-api.md#java_speaker) [Python](python-api.md#python_speaker) [MATLAB](matlab-api.md#matlab_speaker) [ROS](ros-api.md)
 
 ```c
 #include <webots/speaker.h>

--- a/reference/supervisor.md
+++ b/reference/supervisor.md
@@ -30,7 +30,7 @@ As for a regular [Robot](robot.md) controller, the `wb_robot_init`, `wb_robot_st
 
 #### `wb_supervisor_export_image`
 
-[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -65,7 +65,7 @@ In this example, the [Supervisor](#supervisor) controller takes a snapshot image
 #### `wb_supervisor_node_get_self`
 #### `wb_supervisor_node_get_selected`
 
-[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -126,7 +126,7 @@ If no node is currently selected, the function returns NULL.
 #### `wb_supervisor_node_get_type_name`
 #### `wb_supervisor_node_get_base_type_name`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -160,7 +160,7 @@ These integers can be directly compared with the output of the `Node::getType` f
 
 #### `wb_supervisor_node_remove`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -178,7 +178,7 @@ The `wb_supervisor_node_remove` function removes the node specified as an argume
 
 #### `wb_supervisor_node_get_field`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -203,7 +203,7 @@ Otherwise, it returns a handler to a field.
 #### `wb_supervisor_node_get_position`
 #### `wb_supervisor_node_get_orientation`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -253,7 +253,7 @@ The "WEBOTS\_HOME/projects/robots/ipr/worlds/ipr\_cube.wbt" project shows how to
 
 #### `wb_supervisor_node_get_center_of_mass`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -278,7 +278,7 @@ The "WEBOTS\_HOME/projects/samples/.wbt" project shows how to use this function.
 
 #### `wb_supervisor_node_get_contact_point`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -305,7 +305,7 @@ The "WEBOTS\_HOME/projects/samples/howto/worlds/cylinder\_stack.wbt" project sho
 
 #### `wb_supervisor_node_get_number_of_contact_points`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -326,7 +326,7 @@ The "WEBOTS\_HOME/projects/samples/howto/worlds/cylinder\_stack.wbt" project sho
 
 #### `wb_supervisor_node_get_static_balance`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -349,7 +349,7 @@ The test consists in checking whether the projection of the center of mass onto 
 #### `wb_supervisor_node_get_velocity`
 #### `wb_supervisor_node_set_velocity`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -378,7 +378,7 @@ The last three are respectively the angular velocities around the x, y and z axe
 
 #### `wb_supervisor_node_reset_physics`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -400,7 +400,7 @@ To stop the inertia of all available solids please refer to [this section](#wb_s
 
 #### `wb_supervisor_node_restart_controller`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -420,7 +420,7 @@ Note that if a robot window is specified for the [Robot](robot.md) node, the rob
 
 #### `wb_supervisor_node_set_visibility`
 
-[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_node) [Java](java-api.md#java_node) [Python](python-api.md#python_node) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -445,7 +445,7 @@ It is relevant to show a node only if it was previously hidden using this functi
 
 #### `wb_supervisor_set_label`
 
-[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -515,7 +515,7 @@ For example the vector `[1 0 1]` represents the magenta color.
 
 #### `wb_supervisor_simulation_quit`
 
-[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -592,7 +592,7 @@ int main(int argc, char *argv[]) {
 
 #### `wb_supervisor_simulation_revert`
 
-[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -613,7 +613,7 @@ You may wish to save some data in a file from your supervisor program in order t
 #### `wb_supervisor_simulation_get_mode`
 #### `wb_supervisor_simulation_set_mode`
 
-[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -653,7 +653,7 @@ The current simulation mode can also be modified by the Webots user, when he's c
 #### `wb_supervisor_load_world`
 #### `wb_supervisor_save_world`
 
-[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -685,7 +685,7 @@ In this case, a simple save operation is performed.
 
 #### `wb_supervisor_simulation_reset_physics`
 
-[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -710,7 +710,7 @@ To stop the inertia of a single [Solid](solid.md) node please refer to [this sec
 #### `wb_supervisor_movie_is_ready`
 #### `wb_supervisor_movie_failed`
 
-[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -753,7 +753,7 @@ After starting a new recording process the returned value is reset to `FALSE`.
 #### `wb_supervisor_animation_start_recording`
 #### `wb_supervisor_animation_stop_recording`
 
-[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -782,7 +782,7 @@ Both `wb_supervisor_animation_start_recording` and `wb_supervisor_animation_stop
 #### `wb_supervisor_field_get_type_name`
 #### `wb_supervisor_field_get_count`
 
-[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -832,7 +832,7 @@ These integers can be directly compared with the output of the `Field::getType` 
 #### `wb_supervisor_field_get_mf_string`
 #### `wb_supervisor_field_get_mf_node`
 
-[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -891,7 +891,7 @@ The type of the field has to match the name of the function used and the index s
 #### `wb_supervisor_field_set_mf_color`
 #### `wb_supervisor_field_set_mf_string`
 
-[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -954,7 +954,7 @@ The "soccer.wbt" world, located in the "projects/samples/demos/worlds" directory
 #### `wb_supervisor_field_insert_mf_string`
 #### `wb_supervisor_field_remove_mf`
 
-[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -995,7 +995,7 @@ The `wb_supervisor_field_remove_mf` function removes an item from a specified mu
 #### `wb_supervisor_field_import_mf_node`
 #### `wb_supervisor_field_import_mf_node_from_string`
 
-[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_field) [Java](java-api.md#java_field) [Python](python-api.md#python_field) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>
@@ -1060,7 +1060,7 @@ For example, a device imported into a Robot node doesn't reset the Robot, so the
 #### `wb_supervisor_virtual_reality_headset_get_position`
 #### `wb_supervisor_virtual_reality_headset_get_orientation`
 
-[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [Matlab](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_supervisor) [Java](java-api.md#java_supervisor) [Python](python-api.md#python_supervisor) [MATLAB](matlab-api.md#matlab_supervisor) [ROS](ros-api.md)
 
 ```c
 #include <webots/supervisor.h>

--- a/reference/supervisor.md
+++ b/reference/supervisor.md
@@ -507,7 +507,7 @@ supervisor_set_label(0,"hello universe",0,0,0.1,0xffff00,0,"Times New Roman");
 
 This will change the label "hello world" defined earlier into "hello universe", using a yellow color for the new text.
 
-> **Note** [Matlab]: In the Matlab version of the `wb_supervisor_set_label` function, the `color` argument must be a vector containing the three RGB components: `[RED GREEN BLUE]`.
+> **Note** [MATLAB]: In the MATLAB version of the `wb_supervisor_set_label` function, the `color` argument must be a vector containing the three RGB components: `[RED GREEN BLUE]`.
 Each component must be a value between 0.0 and 1.0.
 For example the vector `[1 0 1]` represents the magenta color.
 
@@ -678,7 +678,7 @@ If NULL, the current world path is used instead (e.g., a simple save operation).
 The boolean return value indicates the success of the save operation.
 Be aware that this function can overwrite silently existing files, so that the corresponding data may be lost.
 
-> **Note** [C++, Java, Python, Matlab]: In the other APIs, the `Robot.saveWorld` function can be called without argument.
+> **Note** [C++, Java, Python, MATLAB]: In the other APIs, the `Robot.saveWorld` function can be called without argument.
 In this case, a simple save operation is performed.
 
 ---

--- a/reference/touchsensor.md
+++ b/reference/touchsensor.md
@@ -114,7 +114,7 @@ This approximation usually improves as the `basicTimeStep` ([WorldInfo](worldinf
 #### `wb_touch_sensor_get_value`
 #### `wb_touch_sensor_get_values`
 
-[C++](cpp-api.md#cpp_touch_sensor) [Java](java-api.md#java_touch_sensor) [Python](python-api.md#python_touch_sensor) [Matlab](matlab-api.md#matlab_touch_sensor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_touch_sensor) [Java](java-api.md#java_touch_sensor) [Python](python-api.md#python_touch_sensor) [MATLAB](matlab-api.md#matlab_touch_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/touch_sensor.h>
@@ -150,7 +150,7 @@ This function can be used with a sensor of type "force-3d" exclusively.
 
 #### `wb_touch_sensor_get_type`
 
-[C++](cpp-api.md#cpp_touch_sensor) [Java](java-api.md#java_touch_sensor) [Python](python-api.md#python_touch_sensor) [Matlab](matlab-api.md#matlab_touch_sensor) [ROS](ros-api.md)
+[C++](cpp-api.md#cpp_touch_sensor) [Java](java-api.md#java_touch_sensor) [Python](python-api.md#python_touch_sensor) [MATLAB](matlab-api.md#matlab_touch_sensor) [ROS](ros-api.md)
 
 ```c
 #include <webots/touch_sensor.h>

--- a/tests/test_hyperlinks.py
+++ b/tests/test_hyperlinks.py
@@ -58,7 +58,7 @@ class TestHyperlinks(unittest.TestCase):
     def test_tag_hyperlinks(self):
         """Test that a tag-like hyperlinks are valid."""
         for h in self.hyperlinks:
-            if h['name'] in ['C++', 'Java', 'Python', 'ROS', 'Matlab']:
+            if h['name'] in ['C++', 'Java', 'Python', 'ROS', 'MATLAB']:
                 self.assertTrue(
                     '.md' in h['url'],
                     msg='Hyperlink "%s" is wrongly detected as a tag in "%s".' % (h['md'], h['file'])


### PR DESCRIPTION
Preview:

- https://www.cyberbotics.com/doc/guide/index?version=fix-matlab-spelling
- https://www.cyberbotics.com/doc/reference/index?version=fix-matlab-spelling
