### PR TITLE
Document the installation of make and g++ packages

### DIFF
--- a/guide/installation-procedure.md
+++ b/guide/installation-procedure.md
@@ -94,7 +94,7 @@ export WEBOTS_HOME=/home/username/webots
 The export line should however be included in a configuration script like "/etc/profile", so that it is set properly for every session.
 
 Some additional libraries are needed in order to properly run Webots.
-In particular *libjpeg8-dev*, *ffpmeg*, *libpci3* and *libavcodec-extra* have to be installed on the system.
+In particular *make*, *g++*, *libjpeg8-dev*, *ffpmeg*, and *libpci3* have to be installed on the system.
 If you need to compile [controller plugins](controller-plugin.md) or [physics plugins](webots-plugin.md#physics-plugin), then you also have to install *mesa-common-dev* and *libgl1-mesa-dev* packages.
 Other particular libraries could also be required to recompile some of the distributed binary files.
 In this case an error message will be printed in the Webots console mentioning the missing dependency.


### PR DESCRIPTION
These packages are not available in a fresh Ubuntu 18.04 install but they are required to compile any C/C++ controller or plugin.