### PR TITLE
Fix Docs Tabs with Anchors.

### DIFF
--- a/js/viewer.js
+++ b/js/viewer.js
@@ -888,7 +888,7 @@ function openTabFromEvent(evt, name) {
       continue;
     if (href.includes('tab=' + localSetup.tab))
       a[i].setAttribute('href', href.replace('tab=' + localSetup.tab, 'tab=' + name.toLowerCase()));
-    else
+    else if (!href.startsWith('#'))
       a[i].setAttribute('href', href + (href.indexOf('?') > -1 ? '&' : '?') + 'tab=' + name.toLowerCase());
   }
   // open tab


### PR DESCRIPTION
Fix #950 

https://www.cyberbotics.com/doc/reference/supervisor?version=hotfix-docs-tab-with-anchors